### PR TITLE
chore(release): v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,71 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-04-14
+
 ### Added
 
-- **Parenthesisation policy gaps #1, #2, #3** (ADR §4 *Known gaps*):
-  - **Gap #1** — Arithmetic operators `+`, `-`, `*`, `mod` are now
-    explicit entries in `LaTeXGenerator.PRECEDENCE` with correct relative
-    levels (`*`/`mod` = 11, `+`/`-` = 10). Previously these fell to
-    the default 999, which could produce wrong parens when arithmetic
-    expressions appeared as children of same-default-level operators.
-  - **Gap #2** — `LaTeXGenerator.UNARY_PRECEDENCE` dict is the
-    machine-readable policy for unary binding strength (level 20, above
-    all binary operators). Fuzz-mode quirks in `_generate_unary_op`
-    (cardinality `#` with function application, `bigcup`/`bigcap` with
-    prefix-function operands) are documented with citations to fuzz
-    manual §2.3-2.4 rather than inline magic strings. The logic is
-    otherwise unchanged so no output regression occurs.
-  - **Gap #3** — `_generate_set_comprehension` now passes `parent=node`
-    when generating the predicate expression, so nested quantifiers
-    inside `{ x : T | exists ... }` receive their parent context and the
-    always-paren rule fires correctly. This fixes the Q8(b) assessment
-    feedback where the grader expected parens around an existential
-    predicate inside a set comprehension.
+- `EQUAL:` block for expression equality chains — steps joined by `=` instead
+  of `⇔`. Use for natural-number, set, and sequence equational reasoning
+  (e.g., induction base cases). The `connector` field on `ArgueChain` selects
+  the connective: `"iff"` (default, `EQUIV:`/`ARGUE:`) or `"eq"` (`EQUAL:`).
+- Parenthesisation policy implementation (ADR §4, five gaps closed):
+  - Arithmetic operators (`+`, `-`, `*`, `mod`) in PRECEDENCE table
+  - `UNARY_PRECEDENCE` dict as machine-readable policy for unary binding
+  - Set-comprehension predicate now receives parent context; always-paren
+    rules fire for nested quantifiers (fixes Q8(b) assessment feedback)
+  - Cross-product paren exemption documented with Z RM §2.5 citation
+  - Parametrised precedence test matrix (2240 cases, self-maintaining)
+- Phase 1 end-to-end regression suite (`make test-e2e`) — 141 examples
+  under pytest-xdist with exact `.tex` fixture diffs
+- Markdownlint adopted and wired into `make check`
+- CLI help epilog distinguishing default/`--tex-only`/`-i`/`--check-env` modes
+- Two-page reference card (`docs/cheatsheet.pdf`) with proof examples
+- Three getting-started examples (`examples/00_getting_started/`)
+- Ethos agent team for development workflow (`.punt-labs/ethos/`)
+- `py.typed` marker (PEP 561)
+- `install.sh` for macOS and Linux
 
 ### Changed
 
-- Migrated toolchain from hatch to uv.
-- Added Makefile with standard quality gate targets (`make check`, `make test`, etc.).
-- Bumped minimum Python version from 3.10 to 3.12.
-- Updated CI workflow to use uv via `astral-sh/setup-uv`.
-- Consolidated pytest config into pyproject.toml (removed pytest.ini).
-- Replaced `[project.optional-dependencies] dev` with `[dependency-groups] dev`.
-
-### Added (earlier)
-
-- `py.typed` marker (PEP 561)
-- CHANGELOG.md
-- `EQUAL:` block syntax for expression equality chains. Steps are joined by `=`
-  rather than `\Leftrightarrow`, making it correct for natural-number and
-  expression-valued chains (e.g., `length s = length (tail s) + 1`). The
-  `connector` field on `ArgueChain` selects the connective: `"iff"` (default,
-  used by `EQUIV:`/`ARGUE:`) or `"eq"` (used by `EQUAL:`).
-- Renamed internal flag `_in_equiv_block` to `_in_argue_block` in `LaTeXGenerator`
-  to reflect that it covers `EQUIV:`, `ARGUE:`, and `EQUAL:` contexts.
-- Documented the parenthesisation policy as a settled ADR in `docs/DESIGN.md`
-  (§4 *Parenthesisation Policy*): precedence-driven with an enumerable
-  always-paren set for quantifier bodies containing connectives and nested
-  quantifiers in set-comprehension constraints. Z RM citations included.
-  Five known gaps tracked for follow-up work (arithmetic precedence entries,
-  unary precedence unification, set-comprehension parent-arg fix, cross-product
-  rationale capture, and a parametrised precedence-matrix test).
+- Migrated toolchain from hatch to uv
+- Added Makefile with quality gate targets (`make check`, `make test`, etc.)
+- Bumped minimum Python version from 3.10 to 3.12
+- Updated CI workflow to use uv via `astral-sh/setup-uv`
 
 ### Removed
 
 - HTML export with KaTeX rendering (`--html`, `--validate` flags)
-- Bibliography parser (`bib_parser.py`) — was only used by KaTeX export
+- Bibliography parser (`bib_parser.py`) — only used by KaTeX export
+- 19 development-era cruft files from `examples/`
 
 ### Fixed
 
-- `o9` (forward composition) now emits `\semi` instead of `\circ`. `\semi` is
-  the fuzz Chapter 3 macro for schema/relation forward composition. `\circ` is
-  a standard math operator not defined by fuzz.sty. This affected expression
-  generation, text-block substitution, justification escaping, and proof-tree
-  label processing — all nine emission sites updated uniformly. `comp` (backward
-  relational composition, fuzz `\comp`) is unaffected: it maps to a distinct
-  fuzz Chapter 4 macro and was already correct.
-- Stale version `0.1.0` in `__init__.py` (now imports from `__version__.py`)
+- `o9` (forward composition) now emits `\semi` instead of `\circ` — all nine
+  emission sites updated. `comp` (backward, `\comp`) was already correct.
+- Broken tutorial navigation links (relative paths inside `docs/tutorials/`)
+- Stale filenames in `examples/README.md`
+- Wrong tutorial cross-references in two example category READMEs
 
 ## [1.1.0] - 2025-12-01
 

--- a/src/txt2tex/__version__.py
+++ b/src/txt2tex/__version__.py
@@ -1,3 +1,3 @@
 """Defines the version of the txt2tex package."""
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"


### PR DESCRIPTION
## Summary

Version bump 1.1.0 → 1.2.0. Moves CHANGELOG [Unreleased] to [1.2.0].

See CHANGELOG.md for the full release notes. Highlights:
- `EQUAL:` block, `o9 → \semi` fix, paren policy (5 gaps)
- Phase 1 e2e regression suite, markdownlint
- Reference card, CLI help, getting-started examples
- Ethos agent team, student-readiness polish

## Test plan
- [x] make check (3505 tests)
- [x] make lint-md (89 files)
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a version bump and changelog reorganization with no functional code changes beyond updating the package version string. Low risk unless downstream tooling depends on the previous version number format/value.
> 
> **Overview**
> Prepares the `v1.2.0` release by moving the prior *Unreleased* notes into a dated `1.2.0` section and tightening the formatting/structure of the release notes in `CHANGELOG.md`.
> 
> Bumps the package version from `1.1.0` to `1.2.0` in `src/txt2tex/__version__.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a97ba4d0b0cb6ab9b7985e4d10211a4dfbc65ade. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->