### PR TITLE
chore(deps): upgrade Pygments 2.19.2 → 2.20.0 (security)

### DIFF
--- a/examples/11_text_blocks/bibliography_example.tex
+++ b/examples/11_text_blocks/bibliography_example.tex
@@ -11,7 +11,7 @@
 \title{Bibliography Example}
 \author{Example Author}
 \date{2025}
-\hypersetup{pdftitle={Bibliography Example},pdfauthor={Example Author},pdfcreator={txt2tex v1.1.0}}
+\hypersetup{pdftitle={Bibliography Example},pdfauthor={Example Author},pdfcreator={txt2tex v1.2.0}}
 \begin{document}
 
 \maketitle

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 
 [[package]]
@@ -253,11 +253,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Resolves Dependabot alert #2 (Pygments ReDoS). Transitive via pytest.

Also regens the one e2e fixture with the v1.2.0 version string.

- [x] make check (3505 tests)
- [x] make test-e2e (141 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a lockfile-only dependency bump (transitive via test tooling) plus a regenerated example fixture string, with no production logic changes.
> 
> **Overview**
> Resolves a Pygments security update by bumping the locked `pygments` version from `2.19.2` to `2.20.0` in `uv.lock` (including updated artifact URLs/hashes) and adjusting the lockfile `revision`.
> 
> Regenerates the `examples/11_text_blocks/bibliography_example.tex` fixture to reflect `txt2tex v1.2.0` in the PDF metadata (`\hypersetup{...pdfcreator=...}`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee426718ded1c59f2902b41eda2f6d3a26ec0452. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->