### PR TITLE
feat(cli): add --version / -V flag

### DIFF
--- a/src/txt2tex/cli.py
+++ b/src/txt2tex/cli.py
@@ -9,7 +9,7 @@ import sys
 import tempfile
 from pathlib import Path
 
-from txt2tex import __version__
+from txt2tex.__version__ import __version__
 from txt2tex.compile import compile_pdf, copy_latex_files, format_tex, get_latex_dir
 from txt2tex.errors import ErrorFormatter
 from txt2tex.latex_gen import LaTeXGenerator

--- a/src/txt2tex/cli.py
+++ b/src/txt2tex/cli.py
@@ -9,6 +9,7 @@ import sys
 import tempfile
 from pathlib import Path
 
+from txt2tex import __version__
 from txt2tex.compile import compile_pdf, copy_latex_files, format_tex, get_latex_dir
 from txt2tex.errors import ErrorFormatter
 from txt2tex.latex_gen import LaTeXGenerator
@@ -164,6 +165,12 @@ def main() -> int:
         prog="txt2tex",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=_EPILOG,
+    )
+    parser.add_argument(
+        "-V",
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
     )
     parser.add_argument(
         "input",


### PR DESCRIPTION
Standard argparse `action=\"version\"` reading from the package's
`__version__` constant.  Verified:

\`\`\`
$ txt2tex --version
txt2tex 1.3.0

$ txt2tex -V
txt2tex 1.3.0
\`\`\`

Useful when debugging install/version issues (came up after the
v1.3.0 release when a stale pip cache served v1.2.0 from a venv —
without \`--version\` it's harder to confirm what's actually
installed).

No release needed — change lands now, ships with the next feature
bump.

## Test plan

- [x] `make check` — 4700/4700

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a standard argparse `action="version"` flag with no impact on conversion or compilation behavior.
> 
> **Overview**
> The CLI now supports `-V/--version`, printing `txt2tex`'s package `__version__` via argparse's built-in `action="version"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 786d3afe2167f230231c215c6ce5170d7c36955e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->