### PR TITLE
chore(release): v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-05-24
+
+### Added
+
+- **`--version` / `-V` CLI flag** (#46) — prints `txt2tex <version>` using
+  the package `__version__` constant.  Useful when debugging install or
+  cache issues to confirm which version is actually loaded.
+
 ## [1.3.0] - 2026-05-24
 
 ### Added

--- a/examples/11_text_blocks/bibliography_example.tex
+++ b/examples/11_text_blocks/bibliography_example.tex
@@ -11,7 +11,7 @@
 \title{Bibliography Example}
 \author{Example Author}
 \date{2025}
-\hypersetup{pdftitle={Bibliography Example},pdfauthor={Example Author},pdfcreator={txt2tex v1.3.0}}
+\hypersetup{pdftitle={Bibliography Example},pdfauthor={Example Author},pdfcreator={txt2tex v1.3.1}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/algebra_basics.tex
+++ b/examples/14_relational_databases/algebra_basics.tex
@@ -10,7 +10,7 @@
 \newdimen\savedleftskip
 \title{Relational Algebra}
 \author{txt2tex example}
-\hypersetup{pdftitle={Relational Algebra},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.3.0}}
+\hypersetup{pdftitle={Relational Algebra},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.3.1}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/bindings.tex
+++ b/examples/14_relational_databases/bindings.tex
@@ -10,7 +10,7 @@
 \newdimen\savedleftskip
 \title{Z Binding Calculus}
 \author{txt2tex example}
-\hypersetup{pdftitle={Z Binding Calculus},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.3.0}}
+\hypersetup{pdftitle={Z Binding Calculus},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.3.1}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/foreign_keys.tex
+++ b/examples/14_relational_databases/foreign_keys.tex
@@ -10,7 +10,7 @@
 \newdimen\savedleftskip
 \title{Foreign Keys in Relational Schemas}
 \author{txt2tex example}
-\hypersetup{pdftitle={Foreign Keys in Relational Schemas},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.3.0}}
+\hypersetup{pdftitle={Foreign Keys in Relational Schemas},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.3.1}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/group_ungroup.tex
+++ b/examples/14_relational_databases/group_ungroup.tex
@@ -10,7 +10,7 @@
 \newdimen\savedleftskip
 \title{GROUP and UNGROUP}
 \author{txt2tex example}
-\hypersetup{pdftitle={GROUP and UNGROUP},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.3.0}}
+\hypersetup{pdftitle={GROUP and UNGROUP},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.3.1}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/normalisation.tex
+++ b/examples/14_relational_databases/normalisation.tex
@@ -10,7 +10,7 @@
 \newdimen\savedleftskip
 \title{Functional Dependencies and Normalisation}
 \author{txt2tex example}
-\hypersetup{pdftitle={Functional Dependencies and Normalisation},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.3.0}}
+\hypersetup{pdftitle={Functional Dependencies and Normalisation},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.3.1}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/primary_keys.tex
+++ b/examples/14_relational_databases/primary_keys.tex
@@ -10,7 +10,7 @@
 \newdimen\savedleftskip
 \title{Primary Keys in Relational Schemas}
 \author{txt2tex example}
-\hypersetup{pdftitle={Primary Keys in Relational Schemas},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.3.0}}
+\hypersetup{pdftitle={Primary Keys in Relational Schemas},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.3.1}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/relational_calculus.tex
+++ b/examples/14_relational_databases/relational_calculus.tex
@@ -10,7 +10,7 @@
 \newdimen\savedleftskip
 \title{Relational Calculus --- Music Library}
 \author{txt2tex example}
-\hypersetup{pdftitle={Relational Calculus --- Music Library},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.3.0}}
+\hypersetup{pdftitle={Relational Calculus --- Music Library},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.3.1}}
 \begin{document}
 
 \maketitle

--- a/examples/16_multi_decl_calculus/q2d_demo.tex
+++ b/examples/16_multi_decl_calculus/q2d_demo.tex
@@ -10,7 +10,7 @@
 \newdimen\savedleftskip
 \title{Multi-Declaration Z Constructs --- Demo}
 \author{txt2tex}
-\hypersetup{pdftitle={Multi-Declaration Z Constructs --- Demo},pdfauthor={txt2tex},pdfcreator={txt2tex v1.3.0}}
+\hypersetup{pdftitle={Multi-Declaration Z Constructs --- Demo},pdfauthor={txt2tex},pdfcreator={txt2tex v1.3.1}}
 \begin{document}
 
 \maketitle

--- a/src/txt2tex/__version__.py
+++ b/src/txt2tex/__version__.py
@@ -1,3 +1,3 @@
 """Defines the version of the txt2tex package."""
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"


### PR DESCRIPTION
Patch release.

## Headline

- `--version` / `-V` CLI flag (#46)

## Bundled

- Regenerated nine `.tex` fixtures whose `pdfcreator` field embeds the
  package version (would have broken `make test-e2e` otherwise — same
  issue Copilot flagged on the v1.3.0 PR).

## Test plan

- [x] `make check` — 4700/4700
- [x] `make test-e2e` — 159/159

Tag, build, TestPyPI → PyPI, GitHub release happen after merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk patch release changes: bumps the package version and updates changelog and generated `.tex` fixtures; no core parsing/generation logic is modified in this diff.
> 
> **Overview**
> Updates the project for the `v1.3.1` release by bumping `__version__` and adding a `1.3.1` changelog entry documenting the new `--version`/`-V` CLI flag.
> 
> Regenerates example `.tex` fixtures to reflect the new embedded `pdfcreator` metadata (`txt2tex v1.3.1`), keeping e2e fixture diffs stable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53e2eae5bca3e7693c446a4c383906fd8a6aa597. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->