### PR TITLE
fix(refactor-diff): decide success on .tex presence, not subprocess exit code

### DIFF
--- a/scripts/refactor_diff.py
+++ b/scripts/refactor_diff.py
@@ -76,13 +76,22 @@ def out_key(txt: Path) -> str:
 
 
 def generate_one(txt: Path, dst: Path) -> tuple[Path, bool]:
-    """Run txt2tex on `txt`, write output to `dst`.  Return (dst, ok)."""
+    """Run txt2tex on `txt`, write output to `dst`.  Return (dst, ok).
+
+    The contract is byte-equality of the generated ``.tex`` file.  We
+    therefore decide success on file presence, not on the subprocess
+    exit code: ``txt2tex --tex-only`` exits non-zero when fuzz emits
+    a type-check warning even though the ``.tex`` was generated
+    correctly, and that ``.tex`` is exactly the artifact we want to
+    compare.  Only when no file was produced do we record a sentinel
+    so that verify can detect a *change* in rejection status.
+    """
     dst.parent.mkdir(parents=True, exist_ok=True)
     uv = shutil.which("uv")
     if uv is None:
         print("ERROR: uv not found on PATH", file=sys.stderr)
         sys.exit(2)
-    result = subprocess.run(
+    subprocess.run(
         [
             uv,
             "run",
@@ -97,8 +106,8 @@ def generate_one(txt: Path, dst: Path) -> tuple[Path, bool]:
         text=True,
         cwd=str(ROOT),
     )
-    if result.returncode != 0 or not dst.exists():
-        # Record the failure so verify can detect a *change* in failure status.
+    if not dst.exists():
+        # Genuine rejection — txt2tex declined to produce any output.
         dst.write_text(FAILURE_SENTINEL)
         return dst, False
     return dst, True


### PR DESCRIPTION
## Summary

Follow-up to #51.  The `make refactor-diff` gate had a second bug
on top of the ROOT-cwd issue that #51 fixed: `txt2tex --tex-only`
exits non-zero when fuzz emits a type-check *warning* even though
the `.tex` was generated correctly.  The script treated any
non-zero exit as a rejection and wrote a sentinel — so the real
`.tex` was discarded and the comparison degenerated into
sentinel-vs-sentinel.

This was exposed by running the now-correct gate against
`v1.3.1`:

```
capture: 180 ok, 10 failed/rejected, total 190
PASS: 190 inputs match baseline
```

Five of those "rejected" inputs were `examples/` fixtures that
test-e2e already verifies, so the overall byte-equality claim
still held — but the marginal value of `make refactor-diff` over
test-e2e (the `tests/bugs/` cases) was silently sentinel-matching.

## Fix

Decide success purely on `dst.exists()`.  The `.tex` file is the
artifact the gate is meant to compare; the subprocess exit code
carries downstream fuzz/latexmk warnings that are not part of the
contract.

## Verification

After the fix:

```
$ make refactor-diff REF=v1.3.1
capture: 185 ok, 5 failed/rejected, total 190
PASS: 190 inputs match baseline
```

The remaining 5 rejections are intentional negative-regression
tests in `tests/bugs/` that verify the parser refuses malformed
input (`bug1_prose_period`, `feature_bag_syntax_in_free_types`,
three `regression_in_*` cases).  Sentinel-vs-sentinel is the
correct semantic there.

So Phase 1 is genuinely byte-clean against `v1.3.1`: 185
generated `.tex` files byte-identical, 5 inputs reject in both
versions.

## Test plan

- [x] `make check` clean.
- [x] `make refactor-diff REF=v1.3.1` PASS 190/190 (185 real
  comparisons, 5 intentional rejections).
- [ ] Address bot review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows a regression-gate heuristic in tooling only; no runtime auth, data, or product behavior changes.
> 
> **Overview**
> Fixes **`make refactor-diff`** so it no longer treats a non-zero **`txt2tex --tex-only`** exit as failure when a **`.tex`** file was still written.
> 
> **`generate_one`** now records success only when the output path exists; warnings that make the subprocess exit non-zero no longer trigger the failure sentinel or discard the generated **`.tex`**. Sentinels are written only when no output file is produced, preserving detection of real rejections (e.g. **`tests/bugs/`** negative cases).
> 
> Docstring in **`scripts/refactor_diff.py`** explains that byte-equality of **`.tex`** is the contract, not the subprocess status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8477e9407f0f65df6b8be8fcbf693cfd3db89f38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->