### PR TITLE
chore(release): v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-05-25
+
+### Added
+
+- **Multiple predicates in `zed` blocks** — `zed...end` now accepts
+  any number of predicate expressions, separated by `\also` in the
+  LaTeX output.  Previously only one expression was allowed per
+  block; a second `forall` on the next line raised a parser error.
+- **`make refactor-diff`** — byte-for-byte regression gate that
+  compares `.tex` output against an arbitrary git ref (default
+  `main`) over a 190-input corpus (`examples/` + `tests/bugs/`).
+  See `scripts/refactor_diff.py` and `scripts/refactor_diff_vs_ref.sh`.
+
 ### Changed
 
 - **Family-line split of `latex_gen.py` and `parser.py`** (Phase 1
@@ -24,14 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     (paragraphs, schemas, proofs, algebra, expressions, types,
     text-blocks, lexer-state, errors) plus a `_base.py` type-shape
     declaration.
-
-### Added
-
-- **`make refactor-diff`** — byte-for-byte regression gate that
-  compares `.tex` output against an arbitrary git ref (default
-  `main`) over a 190-input corpus (`examples/` + `tests/bugs/`).
-  Used during the family-line split to verify every batch.  See
-  `scripts/refactor_diff.py` and `scripts/refactor_diff_vs_ref.sh`.
+- **FK example rewritten** — `examples/14_relational_databases/foreign_keys.txt`
+  replaced the semantically-vacuous `elem FK` binding pattern with
+  proper Z predicates (`forall`/`exists` and `pi`/`subset`) that
+  express referential integrity correctly.
 
 ## [1.3.1] - 2026-05-24
 

--- a/examples/11_text_blocks/bibliography_example.tex
+++ b/examples/11_text_blocks/bibliography_example.tex
@@ -11,7 +11,7 @@
 \title{Bibliography Example}
 \author{Example Author}
 \date{2025}
-\hypersetup{pdftitle={Bibliography Example},pdfauthor={Example Author},pdfcreator={txt2tex v1.3.1}}
+\hypersetup{pdftitle={Bibliography Example},pdfauthor={Example Author},pdfcreator={txt2tex v1.4.0}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/algebra_basics.tex
+++ b/examples/14_relational_databases/algebra_basics.tex
@@ -10,7 +10,7 @@
 \newdimen\savedleftskip
 \title{Relational Algebra}
 \author{txt2tex example}
-\hypersetup{pdftitle={Relational Algebra},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.3.1}}
+\hypersetup{pdftitle={Relational Algebra},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.4.0}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/bindings.tex
+++ b/examples/14_relational_databases/bindings.tex
@@ -10,7 +10,7 @@
 \newdimen\savedleftskip
 \title{Z Binding Calculus}
 \author{txt2tex example}
-\hypersetup{pdftitle={Z Binding Calculus},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.3.1}}
+\hypersetup{pdftitle={Z Binding Calculus},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.4.0}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/foreign_keys.tex
+++ b/examples/14_relational_databases/foreign_keys.tex
@@ -10,7 +10,7 @@
 \newdimen\savedleftskip
 \title{Foreign Keys in Relational Schemas}
 \author{txt2tex example}
-\hypersetup{pdftitle={Foreign Keys in Relational Schemas},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.3.1}}
+\hypersetup{pdftitle={Foreign Keys in Relational Schemas},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.4.0}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/group_ungroup.tex
+++ b/examples/14_relational_databases/group_ungroup.tex
@@ -10,7 +10,7 @@
 \newdimen\savedleftskip
 \title{GROUP and UNGROUP}
 \author{txt2tex example}
-\hypersetup{pdftitle={GROUP and UNGROUP},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.3.1}}
+\hypersetup{pdftitle={GROUP and UNGROUP},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.4.0}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/normalisation.tex
+++ b/examples/14_relational_databases/normalisation.tex
@@ -10,7 +10,7 @@
 \newdimen\savedleftskip
 \title{Functional Dependencies and Normalisation}
 \author{txt2tex example}
-\hypersetup{pdftitle={Functional Dependencies and Normalisation},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.3.1}}
+\hypersetup{pdftitle={Functional Dependencies and Normalisation},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.4.0}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/primary_keys.tex
+++ b/examples/14_relational_databases/primary_keys.tex
@@ -10,7 +10,7 @@
 \newdimen\savedleftskip
 \title{Primary Keys in Relational Schemas}
 \author{txt2tex example}
-\hypersetup{pdftitle={Primary Keys in Relational Schemas},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.3.1}}
+\hypersetup{pdftitle={Primary Keys in Relational Schemas},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.4.0}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/relational_calculus.tex
+++ b/examples/14_relational_databases/relational_calculus.tex
@@ -10,7 +10,7 @@
 \newdimen\savedleftskip
 \title{Relational Calculus --- Music Library}
 \author{txt2tex example}
-\hypersetup{pdftitle={Relational Calculus --- Music Library},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.3.1}}
+\hypersetup{pdftitle={Relational Calculus --- Music Library},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.4.0}}
 \begin{document}
 
 \maketitle

--- a/examples/16_multi_decl_calculus/q2d_demo.tex
+++ b/examples/16_multi_decl_calculus/q2d_demo.tex
@@ -10,7 +10,7 @@
 \newdimen\savedleftskip
 \title{Multi-Declaration Z Constructs --- Demo}
 \author{txt2tex}
-\hypersetup{pdftitle={Multi-Declaration Z Constructs --- Demo},pdfauthor={txt2tex},pdfcreator={txt2tex v1.3.1}}
+\hypersetup{pdftitle={Multi-Declaration Z Constructs --- Demo},pdfauthor={txt2tex},pdfcreator={txt2tex v1.4.0}}
 \begin{document}
 
 \maketitle

--- a/src/txt2tex/__version__.py
+++ b/src/txt2tex/__version__.py
@@ -1,3 +1,3 @@
 """Defines the version of the txt2tex package."""
 
-__version__ = "1.3.1"
+__version__ = "1.4.0"


### PR DESCRIPTION
## Summary

Release v1.4.0.  Version bump, CHANGELOG update, e2e fixture
regeneration (pdfcreator stamp).

### Highlights

- **Phase 1 family-line split** — `latex_gen.py` 6,864→598 lines
  (91.3%), `parser.py` 6,367→846 lines (86.7%).  Behaviour
  unchanged; 190/190 byte-identical vs v1.3.1.
- **Multiple predicates in `zed` blocks** — `zed...end` now accepts
  any number of expressions, separated by `\also`.
- **FK example rewritten** — proper Z predicates replace the
  semantically-vacuous `elem FK` pattern.
- **`make refactor-diff`** — new byte-for-byte regression gate.

## Test plan

- [x] `make check` — 4702 tests, clean.
- [x] `make test-e2e` — 159/159 byte-identical.
- [x] Fixture diffs are pdfcreator stamp only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and documentation-only diff in the PR; example output changes are metadata stamps only.
> 
> **Overview**
> **Release v1.4.0** bumps `__version__` to **1.4.0** and documents the release in **CHANGELOG** (multi-predicate `zed` blocks, `make refactor-diff`, Phase 1 parser/codegen split, FK example rewrite). Checked-in example `.tex` files only update **hyperref** `pdfcreator` from `txt2tex v1.3.1` to `v1.4.0`; no other LaTeX content changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04d3d55b83a592639031883c52f04d4bfe448b38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->