### PR TITLE
feat(codegen): underline PK fields in schema rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **PK fields rendered with underline** — primary-key attributes
+  in schemas now render as `\underline{field}` inside the schema
+  box, matching the instructor's format.  Uses a dual-emit
+  technique: fuzz type-checks a hidden plain copy; pdflatex renders
+  a `schemapk` copy with underlines.  The old
+  `\mathrm{PK}(Name) = \{...\}` line below the box is removed.
+
 ## [1.5.0] - 2026-05-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ Fleet[ID/shipID]
 pk shipID
 ```
 
-Primary key annotation (`pk`), FK predicates in `axdef`, relational algebra (Restrict `sigma[p](R)`, Project `pi[A,B](R)`, Rename `R[NEW/OLD]` postfix, Join `R join S`, division `R div S`), and `GROUP`/`UNGROUP` for nested relations (Date's operators).
+Primary key underline (`pk` — renders `\underline{field}` inside the schema box), FK predicates in `axdef`, relational algebra (Restrict `sigma[p](R)`, Project `pi[A,B](R)`, Rename `R[NEW/OLD]` postfix, Join `R join S`, division `R div S`), and `GROUP`/`UNGROUP` for nested relations (Date's operators).
 
 ---
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -2032,6 +2032,11 @@ primitives available in every LaTeX distribution.
 
 ## ADR: Remove relvars, Add pk Primary-Key PK-Line Annotation (Phase 2.1 revised)
 
+> **SUPERSEDED** by "ADR: pk Primary-Key Underline via Dual-Emit
+> (Phase 2.1 revised 2)" below.  The PK-line approach described here
+> has been replaced by `\underline{field}` inside a `schemapk`
+> environment.
+
 **Decision**: Remove the `relvars` declaration feature entirely.  Replace it
 with a `pk` prefix in **named schema bodies only**.  The generator emits a
 plain-math PK statement after the schema box rather than using `\underline{}`
@@ -2112,6 +2117,61 @@ names are comma-separated inside the set literal.
 4. *Capitalisation heuristic* — rejected: single-letter type variables (`N`,
    `Z`, `X`) are uppercase but not relation names; explicit declaration is
    required.
+
+## ADR: pk Primary-Key Underline via Dual-Emit (Phase 2.1 revised 2)
+
+**Decision**: Render `pk`-marked attributes with `\underline{field}` inside
+the schema box, matching the instructor's format.  Use dual-emit to keep
+fuzz happy.
+
+**Supersedes**: "ADR: Remove relvars, Add pk Primary-Key PK-Line Annotation
+(Phase 2.1 revised)" above.  The `\mathrm{PK}(Name) = \{...\}` line is
+removed.
+
+**Context**: The instructor's slides and worksheets underline primary-key
+attributes inside schema boxes.  The previous ADR rejected `\underline{}`
+because fuzz's schema parser requires a plain identifier in the variable-name
+position — any macro with braces is a syntax error.
+
+**Dual-emit technique**: For schemas with at least one `pk` field, the
+generator emits two copies:
+
+1. A fuzz-checked copy inside `\setbox0=\vbox{%...\end{schema}%\n}`.  fuzz
+   sees `\begin{schema}` with plain identifiers and type-checks it.  pdflatex
+   typesets the content into a discarded box register — it never appears in
+   the PDF.
+
+2. A rendered copy using `\begin{schemapk}{Name}` with `\underline{field}`
+   on each PK attribute.  The `schemapk` environment (defined in
+   `schemapk.sty` as a clone of `schema`) is unknown to fuzz, so fuzz skips
+   it.  pdflatex renders it identically to a normal schema, with underlines.
+
+Schemas without PK fields emit `\begin{schema}` as before — no `\setbox`,
+no `schemapk`.
+
+**`schemapk.sty`**: Bundled in `src/txt2tex/latex/`, auto-copied by the
+`glob("*.sty")` pattern in `compile.py`.  Contents:
+
+```latex
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesPackage{schemapk}
+\newenvironment{schemapk}[1]{\begin{schema}{#1}}{\end{schema}}
+```
+
+**Compound PKs**: Each PK field is underlined independently.  A schema
+with `pk a : T` and `pk b : U` renders `\underline{a} : T` and
+`\underline{b} : U`.
+
+**Options considered**:
+
+1. *`\underline{field}` directly in `\begin{schema}`* — rejected: fuzz
+   syntax error on `{` in the identifier position.
+2. *fuzz pragmas (`%%ignore`, `%%zap`, `%%cmd`)* — tested; none exist.
+3. *Custom fuzz prelude* — rejected: would require modifying fuzz internals.
+4. *Post-processing the .tex after fuzz* — rejected: the committed .tex
+   would differ from what fuzz checked.
+5. *`schemapk`-only (no fuzz copy)* — rejected: the schema must be
+   fuzz-validated.
 
 ## ADR: WYSIWYG Line Breaks for Algebra and Set Operators
 

--- a/docs/guides/USER_GUIDE.md
+++ b/docs/guides/USER_GUIDE.md
@@ -2802,8 +2802,8 @@ decomposition), see
 ### pk Declaration
 
 Mark an attribute as a primary key with the `pk` prefix inside a **named**
-schema body.  txt2tex emits a fuzz-compatible PK statement after the schema
-box:
+schema body.  txt2tex renders `pk` fields with `\underline{field}` inside
+the schema box:
 
 ```text
 schema Book
@@ -2816,16 +2816,16 @@ end
 Generated LaTeX (abridged):
 
 ```latex
-\begin{schema}{Book}
-bookId : BookId \\
+\begin{schemapk}{Book}
+\underline{bookId} : BookId \\
 isbn : ISBN \\
 pages : \nat
-\end{schema}
-\noindent$\mathrm{PK}(\mathrm{Book}) = \{bookId\}$
+\end{schemapk}
 ```
 
-The schema body stays plain so fuzz type-checks it cleanly.  The PK line
-sits outside the Z environment and is rendered by pdflatex.
+Fuzz type-checks the schema via a hidden plain copy (using
+`\setbox0=\vbox{...}`).  The rendered copy uses the `schemapk`
+environment, which fuzz ignores.
 
 **Composite primary key** — two or more `pk` lines:
 
@@ -2836,7 +2836,8 @@ schema CentreStaff
 end
 ```
 
-Emits: `\noindent$\mathrm{PK}(\mathrm{CentreStaff}) = \{centreId, staffId\}$`
+Each PK field is underlined independently:
+`\underline{centreId}` and `\underline{staffId}`.
 
 **Comma-separated pk names** (when names share a type):
 

--- a/examples/00_getting_started/basic_z_notation.tex
+++ b/examples/00_getting_started/basic_z_notation.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/00_getting_started/decorated_identifiers.tex
+++ b/examples/00_getting_started/decorated_identifiers.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/00_getting_started/first_proof.tex
+++ b/examples/00_getting_started/first_proof.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/00_getting_started/hello_world.tex
+++ b/examples/00_getting_started/hello_world.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/00_getting_started/string_literals.tex
+++ b/examples/00_getting_started/string_literals.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/01_propositional_logic/basic_operators.tex
+++ b/examples/01_propositional_logic/basic_operators.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/01_propositional_logic/complex_formulas.tex
+++ b/examples/01_propositional_logic/complex_formulas.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/01_propositional_logic/hello_world.tex
+++ b/examples/01_propositional_logic/hello_world.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/01_propositional_logic/truth_tables.tex
+++ b/examples/01_propositional_logic/truth_tables.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/02_predicate_logic/declarations.tex
+++ b/examples/02_predicate_logic/declarations.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/02_predicate_logic/quantifiers.tex
+++ b/examples/02_predicate_logic/quantifiers.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/03_equality/bullet_separator.tex
+++ b/examples/03_equality/bullet_separator.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/03_equality/equality_operators.tex
+++ b/examples/03_equality/equality_operators.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/03_equality/mu_operator.tex
+++ b/examples/03_equality/mu_operator.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/03_equality/mu_with_expression.tex
+++ b/examples/03_equality/mu_with_expression.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/03_equality/one_point_rule.tex
+++ b/examples/03_equality/one_point_rule.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/03_equality/unique_existence.tex
+++ b/examples/03_equality/unique_existence.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/04_proof_trees/advanced_proof_patterns.tex
+++ b/examples/04_proof_trees/advanced_proof_patterns.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/04_proof_trees/contradiction.tex
+++ b/examples/04_proof_trees/contradiction.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/04_proof_trees/excluded_middle.tex
+++ b/examples/04_proof_trees/excluded_middle.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/04_proof_trees/infrule_modus_ponens.tex
+++ b/examples/04_proof_trees/infrule_modus_ponens.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/04_proof_trees/minimal_nesting.tex
+++ b/examples/04_proof_trees/minimal_nesting.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/04_proof_trees/nested_proofs.tex
+++ b/examples/04_proof_trees/nested_proofs.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/04_proof_trees/pattern_matching.tex
+++ b/examples/04_proof_trees/pattern_matching.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/04_proof_trees/shows_operator.tex
+++ b/examples/04_proof_trees/shows_operator.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/04_proof_trees/simple_proofs.tex
+++ b/examples/04_proof_trees/simple_proofs.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/05_sets/cartesian_tuples.tex
+++ b/examples/05_sets/cartesian_tuples.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/05_sets/set_basics.tex
+++ b/examples/05_sets/set_basics.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/05_sets/set_literals.tex
+++ b/examples/05_sets/set_literals.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/05_sets/set_operations.tex
+++ b/examples/05_sets/set_operations.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/05_sets/strict_subset.tex
+++ b/examples/05_sets/strict_subset.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/05_sets/tuple_examples.tex
+++ b/examples/05_sets/tuple_examples.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/05_sets/union_domain.tex
+++ b/examples/05_sets/union_domain.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/06_definitions/abbrev_demo.tex
+++ b/examples/06_definitions/abbrev_demo.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/06_definitions/anonymous_schema.tex
+++ b/examples/06_definitions/anonymous_schema.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/06_definitions/axdef_demo.tex
+++ b/examples/06_definitions/axdef_demo.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/06_definitions/free_types_demo.tex
+++ b/examples/06_definitions/free_types_demo.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/06_definitions/free_types_proper.tex
+++ b/examples/06_definitions/free_types_proper.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/06_definitions/gendef_advanced.tex
+++ b/examples/06_definitions/gendef_advanced.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/06_definitions/gendef_basic.tex
+++ b/examples/06_definitions/gendef_basic.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/06_definitions/schema_demo.tex
+++ b/examples/06_definitions/schema_demo.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/06_definitions/syntax_demo.tex
+++ b/examples/06_definitions/syntax_demo.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/07_relations/domain_range.tex
+++ b/examples/07_relations/domain_range.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/07_relations/maplets.tex
+++ b/examples/07_relations/maplets.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/07_relations/range_examples.tex
+++ b/examples/07_relations/range_examples.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/07_relations/relation_operators.tex
+++ b/examples/07_relations/relation_operators.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/07_relations/relational_composition.tex
+++ b/examples/07_relations/relational_composition.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/07_relations/relational_image.tex
+++ b/examples/07_relations/relational_image.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/07_relations/restrictions.tex
+++ b/examples/07_relations/restrictions.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/08_functions/composition_pipelines.tex
+++ b/examples/08_functions/composition_pipelines.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/08_functions/finite_functions.tex
+++ b/examples/08_functions/finite_functions.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/08_functions/function_composition.tex
+++ b/examples/08_functions/function_composition.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/08_functions/function_definitions_simple.tex
+++ b/examples/08_functions/function_definitions_simple.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/08_functions/higher_order_functions.tex
+++ b/examples/08_functions/higher_order_functions.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/08_functions/lambda_expressions.tex
+++ b/examples/08_functions/lambda_expressions.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/08_functions/sequence_tuple_tests.tex
+++ b/examples/08_functions/sequence_tuple_tests.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/08_functions/sequences_bags_tuples.tex
+++ b/examples/08_functions/sequences_bags_tuples.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/09_sequences/bags.tex
+++ b/examples/09_sequences/bags.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/09_sequences/concatenation.tex
+++ b/examples/09_sequences/concatenation.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/09_sequences/pattern_matching.tex
+++ b/examples/09_sequences/pattern_matching.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/09_sequences/sequence_basics.tex
+++ b/examples/09_sequences/sequence_basics.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/09_sequences/sequence_filter.tex
+++ b/examples/09_sequences/sequence_filter.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/09_sequences/sequence_operations.tex
+++ b/examples/09_sequences/sequence_operations.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/09_sequences/user_defined_squash.tex
+++ b/examples/09_sequences/user_defined_squash.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/10_schemas/also_blank_lines.tex
+++ b/examples/10_schemas/also_blank_lines.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/10_schemas/delta_xi_inclusion.tex
+++ b/examples/10_schemas/delta_xi_inclusion.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/10_schemas/horizontal_defs.tex
+++ b/examples/10_schemas/horizontal_defs.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/10_schemas/schema_as_predicate.tex
+++ b/examples/10_schemas/schema_as_predicate.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/10_schemas/schema_rename.tex
+++ b/examples/10_schemas/schema_rename.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/10_schemas/scoping_demo.tex
+++ b/examples/10_schemas/scoping_demo.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/10_schemas/theta_binding.tex
+++ b/examples/10_schemas/theta_binding.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/10_schemas/zed_blocks.tex
+++ b/examples/10_schemas/zed_blocks.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/11_text_blocks/bibliography_example.tex
+++ b/examples/11_text_blocks/bibliography_example.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/11_text_blocks/combined_directives.tex
+++ b/examples/11_text_blocks/combined_directives.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/11_text_blocks/latex_passthrough.tex
+++ b/examples/11_text_blocks/latex_passthrough.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/11_text_blocks/pagebreak.tex
+++ b/examples/11_text_blocks/pagebreak.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/11_text_blocks/puretext.tex
+++ b/examples/11_text_blocks/puretext.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/11_text_blocks/text_smart.tex
+++ b/examples/11_text_blocks/text_smart.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/12_advanced/generic_instantiation.tex
+++ b/examples/12_advanced/generic_instantiation.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/12_advanced/if_then_else.tex
+++ b/examples/12_advanced/if_then_else.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/12_advanced/subscripts_superscripts.tex
+++ b/examples/12_advanced/subscripts_superscripts.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/13_equality_chains/equality_chain_basic.tex
+++ b/examples/13_equality_chains/equality_chain_basic.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/14_relational_databases/algebra_basics.tex
+++ b/examples/14_relational_databases/algebra_basics.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/14_relational_databases/bindings.tex
+++ b/examples/14_relational_databases/bindings.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/14_relational_databases/foreign_keys.tex
+++ b/examples/14_relational_databases/foreign_keys.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip
@@ -25,22 +26,29 @@
 
 \bigskip
 
+\setbox0=\vbox{%
 \begin{schema}{Recipe}
 recipeId : RecipeId \\
 name : RecipeName \\
 cuisine : CuisineTag
-\end{schema}
-\noindent$\mathrm{PK}(\mathrm{Recipe}) = \{recipeId\}$
+\end{schema}%
+}
+\begin{schemapk}{Recipe}
+\underline{recipeId} : RecipeId \\
+name : RecipeName \\
+cuisine : CuisineTag
+\end{schemapk}
 
-\smallskip
-
+\setbox0=\vbox{%
 \begin{schema}{Ingredient}
 ingredientId : IngredientId \\
 name : IngredientName
-\end{schema}
-\noindent$\mathrm{PK}(\mathrm{Ingredient}) = \{ingredientId\}$
-
-\smallskip
+\end{schema}%
+}
+\begin{schemapk}{Ingredient}
+\underline{ingredientId} : IngredientId \\
+name : IngredientName
+\end{schemapk}
 
 \medskip
 
@@ -50,13 +58,16 @@ name : IngredientName
 
 \bigskip
 
+\setbox0=\vbox{%
 \begin{schema}{RecipeIngredient}
 recipeId : RecipeId \\
 ingredientId : IngredientId
-\end{schema}
-\noindent$\mathrm{PK}(\mathrm{RecipeIngredient}) = \{recipeId, ingredientId\}$
-
-\smallskip
+\end{schema}%
+}
+\begin{schemapk}{RecipeIngredient}
+\underline{recipeId} : RecipeId \\
+\underline{ingredientId} : IngredientId
+\end{schemapk}
 
 \medskip
 
@@ -108,15 +119,20 @@ $\forall ri : RecipeIngredient @ \exists i : Ingredient @ ri.ingredientId = i.in
 
 \bigskip
 
+\setbox0=\vbox{%
 \begin{schema}{Employee}
 employeeId : EmployeeId \\
 name : EmployeeName \\
 position : PositionName \\
 managerId : EmployeeId
-\end{schema}
-\noindent$\mathrm{PK}(\mathrm{Employee}) = \{employeeId\}$
-
-\smallskip
+\end{schema}%
+}
+\begin{schemapk}{Employee}
+\underline{employeeId} : EmployeeId \\
+name : EmployeeName \\
+position : PositionName \\
+managerId : EmployeeId
+\end{schemapk}
 
 \noindent Every managerId in Employee must match a valid employeeId in the same relation:
 

--- a/examples/14_relational_databases/foreign_keys.tex
+++ b/examples/14_relational_databases/foreign_keys.tex
@@ -26,7 +26,7 @@
 
 \bigskip
 
-\setbox0=\vbox{%
+\savebox{\schemapkbox}{%
 \begin{schema}{Recipe}
 recipeId : RecipeId \\
 name : RecipeName \\
@@ -39,7 +39,7 @@ name : RecipeName \\
 cuisine : CuisineTag
 \end{schemapk}
 
-\setbox0=\vbox{%
+\savebox{\schemapkbox}{%
 \begin{schema}{Ingredient}
 ingredientId : IngredientId \\
 name : IngredientName
@@ -58,7 +58,7 @@ name : IngredientName
 
 \bigskip
 
-\setbox0=\vbox{%
+\savebox{\schemapkbox}{%
 \begin{schema}{RecipeIngredient}
 recipeId : RecipeId \\
 ingredientId : IngredientId
@@ -119,7 +119,7 @@ $\forall ri : RecipeIngredient @ \exists i : Ingredient @ ri.ingredientId = i.in
 
 \bigskip
 
-\setbox0=\vbox{%
+\savebox{\schemapkbox}{%
 \begin{schema}{Employee}
 employeeId : EmployeeId \\
 name : EmployeeName \\

--- a/examples/14_relational_databases/group_ungroup.tex
+++ b/examples/14_relational_databases/group_ungroup.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/14_relational_databases/normalisation.tex
+++ b/examples/14_relational_databases/normalisation.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip
@@ -23,6 +24,7 @@
 
 \bigskip
 
+\setbox0=\vbox{%
 \begin{schema}{Universal}
 empID : EmpID \\
 empName : EmpName \\
@@ -30,10 +32,16 @@ dept : DeptName \\
 deptHead : HeadName \\
 projID : ProjID \\
 projName : ProjName
-\end{schema}
-\noindent$\mathrm{PK}(\mathrm{Universal}) = \{empID, projID\}$
-
-\smallskip
+\end{schema}%
+}
+\begin{schemapk}{Universal}
+\underline{empID} : EmpID \\
+empName : EmpName \\
+dept : DeptName \\
+deptHead : HeadName \\
+\underline{projID} : ProjID \\
+projName : ProjName
+\end{schemapk}
 
 \noindent The relation is in 1NF: every attribute is single-valued and every row is uniquely identified by (empID, projID).
 
@@ -119,38 +127,51 @@ projName : ProjName
 
 \bigskip
 
+\setbox0=\vbox{%
 \begin{schema}{Employee}
 empID : EmpID \\
 empName : EmpName \\
 dept : DeptName
-\end{schema}
-\noindent$\mathrm{PK}(\mathrm{Employee}) = \{empID\}$
+\end{schema}%
+}
+\begin{schemapk}{Employee}
+\underline{empID} : EmpID \\
+empName : EmpName \\
+dept : DeptName
+\end{schemapk}
 
-\smallskip
-
+\setbox0=\vbox{%
 \begin{schema}{Department}
 dept : DeptName \\
 deptHead : HeadName
-\end{schema}
-\noindent$\mathrm{PK}(\mathrm{Department}) = \{dept\}$
+\end{schema}%
+}
+\begin{schemapk}{Department}
+\underline{dept} : DeptName \\
+deptHead : HeadName
+\end{schemapk}
 
-\smallskip
-
+\setbox0=\vbox{%
 \begin{schema}{Project}
 projID : ProjID \\
 projName : ProjName
-\end{schema}
-\noindent$\mathrm{PK}(\mathrm{Project}) = \{projID\}$
+\end{schema}%
+}
+\begin{schemapk}{Project}
+\underline{projID} : ProjID \\
+projName : ProjName
+\end{schemapk}
 
-\smallskip
-
+\setbox0=\vbox{%
 \begin{schema}{Assignment}
 empID : EmpID \\
 projID : ProjID
-\end{schema}
-\noindent$\mathrm{PK}(\mathrm{Assignment}) = \{empID, projID\}$
-
-\smallskip
+\end{schema}%
+}
+\begin{schemapk}{Assignment}
+\underline{empID} : EmpID \\
+\underline{projID} : ProjID
+\end{schemapk}
 
 \noindent Every non-key attribute now depends only on its own primary key. No partial or transitive dependencies remain.  The decomposition is lossless: rejoining Employee, Department, Assignment, and Project on their shared keys reconstructs the original Universal relation exactly.
 

--- a/examples/14_relational_databases/normalisation.tex
+++ b/examples/14_relational_databases/normalisation.tex
@@ -24,7 +24,7 @@
 
 \bigskip
 
-\setbox0=\vbox{%
+\savebox{\schemapkbox}{%
 \begin{schema}{Universal}
 empID : EmpID \\
 empName : EmpName \\
@@ -127,7 +127,7 @@ projName : ProjName
 
 \bigskip
 
-\setbox0=\vbox{%
+\savebox{\schemapkbox}{%
 \begin{schema}{Employee}
 empID : EmpID \\
 empName : EmpName \\
@@ -140,7 +140,7 @@ empName : EmpName \\
 dept : DeptName
 \end{schemapk}
 
-\setbox0=\vbox{%
+\savebox{\schemapkbox}{%
 \begin{schema}{Department}
 dept : DeptName \\
 deptHead : HeadName
@@ -151,7 +151,7 @@ deptHead : HeadName
 deptHead : HeadName
 \end{schemapk}
 
-\setbox0=\vbox{%
+\savebox{\schemapkbox}{%
 \begin{schema}{Project}
 projID : ProjID \\
 projName : ProjName
@@ -162,7 +162,7 @@ projName : ProjName
 projName : ProjName
 \end{schemapk}
 
-\setbox0=\vbox{%
+\savebox{\schemapkbox}{%
 \begin{schema}{Assignment}
 empID : EmpID \\
 projID : ProjID

--- a/examples/14_relational_databases/primary_keys.tex
+++ b/examples/14_relational_databases/primary_keys.tex
@@ -20,7 +20,7 @@
 
 \section*{Single Primary Key}
 
-\setbox0=\vbox{%
+\savebox{\schemapkbox}{%
 \begin{schema}{Book}
 bookId : BookId \\
 isbn : ISBN \\
@@ -35,7 +35,7 @@ pages : \nat \\
 year : \nat
 \end{schemapk}
 
-\setbox0=\vbox{%
+\savebox{\schemapkbox}{%
 \begin{schema}{Member}
 memberId : MemberId \\
 age : \nat
@@ -46,7 +46,7 @@ age : \nat
 age : \nat
 \end{schemapk}
 
-\setbox0=\vbox{%
+\savebox{\schemapkbox}{%
 \begin{schema}{Loan}
 loanId : LoanId \\
 bookId : BookId \\
@@ -63,7 +63,7 @@ daysOut : \nat
 
 \section*{Composite Primary Key}
 
-\setbox0=\vbox{%
+\savebox{\schemapkbox}{%
 \begin{schema}{LoanHistory}
 bookId : BookId \\
 memberId : MemberId

--- a/examples/14_relational_databases/primary_keys.tex
+++ b/examples/14_relational_databases/primary_keys.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip
@@ -19,42 +20,58 @@
 
 \section*{Single Primary Key}
 
+\setbox0=\vbox{%
 \begin{schema}{Book}
 bookId : BookId \\
 isbn : ISBN \\
 pages : \nat \\
 year : \nat
-\end{schema}
-\noindent$\mathrm{PK}(\mathrm{Book}) = \{bookId\}$
+\end{schema}%
+}
+\begin{schemapk}{Book}
+\underline{bookId} : BookId \\
+isbn : ISBN \\
+pages : \nat \\
+year : \nat
+\end{schemapk}
 
-\smallskip
-
+\setbox0=\vbox{%
 \begin{schema}{Member}
 memberId : MemberId \\
 age : \nat
-\end{schema}
-\noindent$\mathrm{PK}(\mathrm{Member}) = \{memberId\}$
+\end{schema}%
+}
+\begin{schemapk}{Member}
+\underline{memberId} : MemberId \\
+age : \nat
+\end{schemapk}
 
-\smallskip
-
+\setbox0=\vbox{%
 \begin{schema}{Loan}
 loanId : LoanId \\
 bookId : BookId \\
 memberId : MemberId \\
 daysOut : \nat
-\end{schema}
-\noindent$\mathrm{PK}(\mathrm{Loan}) = \{loanId\}$
-
-\smallskip
+\end{schema}%
+}
+\begin{schemapk}{Loan}
+\underline{loanId} : LoanId \\
+bookId : BookId \\
+memberId : MemberId \\
+daysOut : \nat
+\end{schemapk}
 
 \section*{Composite Primary Key}
 
+\setbox0=\vbox{%
 \begin{schema}{LoanHistory}
 bookId : BookId \\
 memberId : MemberId
-\end{schema}
-\noindent$\mathrm{PK}(\mathrm{LoanHistory}) = \{bookId, memberId\}$
-
-\smallskip
+\end{schema}%
+}
+\begin{schemapk}{LoanHistory}
+\underline{bookId} : BookId \\
+\underline{memberId} : MemberId
+\end{schemapk}
 
 \end{document}

--- a/examples/14_relational_databases/relational_calculus.tex
+++ b/examples/14_relational_databases/relational_calculus.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/15_schema_calculus/composition.tex
+++ b/examples/15_schema_calculus/composition.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/15_schema_calculus/piping_hiding.tex
+++ b/examples/15_schema_calculus/piping_hiding.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/16_multi_decl_calculus/q2d_demo.tex
+++ b/examples/16_multi_decl_calculus/q2d_demo.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip
@@ -25,34 +26,48 @@
 
 \medskip
 
+\setbox0=\vbox{%
 \begin{schema}{Tournament}
 tournamentId : TournamentId \\
 venue : VenueName \\
 tier : \nat
 \where
 tier \leq 5
-\end{schema}
-\noindent$\mathrm{PK}(\mathrm{Tournament}) = \{tournamentId\}$
+\end{schema}%
+}
+\begin{schemapk}{Tournament}
+\underline{tournamentId} : TournamentId \\
+venue : VenueName \\
+tier : \nat
+\where
+tier \leq 5
+\end{schemapk}
 
-\smallskip
-
+\setbox0=\vbox{%
 \begin{schema}{Player}
 name : PlayerName \\
 ranking : \nat
-\end{schema}
-\noindent$\mathrm{PK}(\mathrm{Player}) = \{name\}$
+\end{schema}%
+}
+\begin{schemapk}{Player}
+\underline{name} : PlayerName \\
+ranking : \nat
+\end{schemapk}
 
-\smallskip
-
+\setbox0=\vbox{%
 \begin{schema}{Match}
 matchId : MatchId \\
 tournament : TournamentId \\
 winner : PlayerName \\
 loser : PlayerName
-\end{schema}
-\noindent$\mathrm{PK}(\mathrm{Match}) = \{matchId, tournament\}$
-
-\smallskip
+\end{schema}%
+}
+\begin{schemapk}{Match}
+\underline{matchId} : MatchId \\
+\underline{tournament} : TournamentId \\
+winner : PlayerName \\
+loser : PlayerName
+\end{schemapk}
 
 \section*{1. WYSIWYG line breaks for algebra operators}
 

--- a/examples/16_multi_decl_calculus/q2d_demo.tex
+++ b/examples/16_multi_decl_calculus/q2d_demo.tex
@@ -26,7 +26,7 @@
 
 \medskip
 
-\setbox0=\vbox{%
+\savebox{\schemapkbox}{%
 \begin{schema}{Tournament}
 tournamentId : TournamentId \\
 venue : VenueName \\
@@ -43,7 +43,7 @@ tier : \nat
 tier \leq 5
 \end{schemapk}
 
-\setbox0=\vbox{%
+\savebox{\schemapkbox}{%
 \begin{schema}{Player}
 name : PlayerName \\
 ranking : \nat
@@ -54,7 +54,7 @@ ranking : \nat
 ranking : \nat
 \end{schemapk}
 
-\setbox0=\vbox{%
+\savebox{\schemapkbox}{%
 \begin{schema}{Match}
 matchId : MatchId \\
 tournament : TournamentId \\

--- a/examples/17_state_machines/turnstile.tex
+++ b/examples/17_state_machines/turnstile.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/fuzz_tests/test_field_projection_bug.tex
+++ b/examples/fuzz_tests/test_field_projection_bug.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/fuzz_tests/test_mod.tex
+++ b/examples/fuzz_tests/test_mod.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/fuzz_tests/test_mod2.tex
+++ b/examples/fuzz_tests/test_mod2.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/fuzz_tests/test_nested_super.tex
+++ b/examples/fuzz_tests/test_nested_super.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/fuzz_tests/test_zed.tex
+++ b/examples/fuzz_tests/test_zed.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/01_document_structure.tex
+++ b/examples/user_guide/01_document_structure.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/02_text_smart.tex
+++ b/examples/user_guide/02_text_smart.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/03_text_citations.tex
+++ b/examples/user_guide/03_text_citations.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/04_puretext.tex
+++ b/examples/user_guide/04_puretext.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/05_latex_passthrough.tex
+++ b/examples/user_guide/05_latex_passthrough.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/06_bibliography_manual.tex
+++ b/examples/user_guide/06_bibliography_manual.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/07_truth_table.tex
+++ b/examples/user_guide/07_truth_table.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/08_equivalence_chains.tex
+++ b/examples/user_guide/08_equivalence_chains.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/09_quantifiers_basic.tex
+++ b/examples/user_guide/09_quantifiers_basic.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/10_quantifiers_bullet.tex
+++ b/examples/user_guide/10_quantifiers_bullet.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/11_mu_operator.tex
+++ b/examples/user_guide/11_mu_operator.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/12_multi_variable_quantifiers.tex
+++ b/examples/user_guide/12_multi_variable_quantifiers.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/13_nested_quantifiers.tex
+++ b/examples/user_guide/13_nested_quantifiers.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/14_set_notation.tex
+++ b/examples/user_guide/14_set_notation.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/15_power_set.tex
+++ b/examples/user_guide/15_power_set.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/16_cartesian_product.tex
+++ b/examples/user_guide/16_cartesian_product.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/17_field_projection.tex
+++ b/examples/user_guide/17_field_projection.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/18_set_comprehension.tex
+++ b/examples/user_guide/18_set_comprehension.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/19_distributed_ops.tex
+++ b/examples/user_guide/19_distributed_ops.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/20_given_types.tex
+++ b/examples/user_guide/20_given_types.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/21_abbreviations.tex
+++ b/examples/user_guide/21_abbreviations.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/22_free_types.tex
+++ b/examples/user_guide/22_free_types.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/23_gendef_basic.tex
+++ b/examples/user_guide/23_gendef_basic.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/24_gendef_multiple_decls.tex
+++ b/examples/user_guide/24_gendef_multiple_decls.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/25_generic_free_type_workaround.tex
+++ b/examples/user_guide/25_generic_free_type_workaround.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/26_generic_schema.tex
+++ b/examples/user_guide/26_generic_schema.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/27_relations_basic.tex
+++ b/examples/user_guide/27_relations_basic.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/28_restrictions.tex
+++ b/examples/user_guide/28_restrictions.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/29_relational_image.tex
+++ b/examples/user_guide/29_relational_image.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/30_composition.tex
+++ b/examples/user_guide/30_composition.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/31_closures.tex
+++ b/examples/user_guide/31_closures.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/32_compound_identifiers.tex
+++ b/examples/user_guide/32_compound_identifiers.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/33_function_types.tex
+++ b/examples/user_guide/33_function_types.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/34_function_application.tex
+++ b/examples/user_guide/34_function_application.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/35_lambda_expressions.tex
+++ b/examples/user_guide/35_lambda_expressions.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/36_function_override.tex
+++ b/examples/user_guide/36_function_override.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/37_range_operator.tex
+++ b/examples/user_guide/37_range_operator.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/38_function_definitions.tex
+++ b/examples/user_guide/38_function_definitions.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/39_function_properties.tex
+++ b/examples/user_guide/39_function_properties.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/40_recursive_functions.tex
+++ b/examples/user_guide/40_recursive_functions.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/41_higher_order_functions.tex
+++ b/examples/user_guide/41_higher_order_functions.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/42_sequence_literals.tex
+++ b/examples/user_guide/42_sequence_literals.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/43_concatenation.tex
+++ b/examples/user_guide/43_concatenation.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/44_sequence_filter.tex
+++ b/examples/user_guide/44_sequence_filter.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/45_sequence_functions.tex
+++ b/examples/user_guide/45_sequence_functions.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/46_pattern_matching.tex
+++ b/examples/user_guide/46_pattern_matching.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/47_bags.tex
+++ b/examples/user_guide/47_bags.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/48_zed_blocks.tex
+++ b/examples/user_guide/48_zed_blocks.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/49_axdef_global_scope.tex
+++ b/examples/user_guide/49_axdef_global_scope.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/50_axdef_basic.tex
+++ b/examples/user_guide/50_axdef_basic.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/51_schema_basic.tex
+++ b/examples/user_guide/51_schema_basic.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/52_anonymous_schema.tex
+++ b/examples/user_guide/52_anonymous_schema.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/53_proof_simple.tex
+++ b/examples/user_guide/53_proof_simple.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/54_proof_case_analysis.tex
+++ b/examples/user_guide/54_proof_case_analysis.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/55_proof_distributivity.tex
+++ b/examples/user_guide/55_proof_distributivity.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/56_conditional_expressions.tex
+++ b/examples/user_guide/56_conditional_expressions.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/57_subscripts_superscripts.tex
+++ b/examples/user_guide/57_subscripts_superscripts.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/58_multi_word_identifiers.tex
+++ b/examples/user_guide/58_multi_word_identifiers.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/59_comparison_operators.tex
+++ b/examples/user_guide/59_comparison_operators.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/60_arithmetic_operators.tex
+++ b/examples/user_guide/60_arithmetic_operators.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/examples/user_guide/61_generic_instantiation.tex
+++ b/examples/user_guide/61_generic_instantiation.tex
@@ -5,6 +5,7 @@
 \usepackage{natbib}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 \usepackage{fuzz}
+\usepackage{schemapk}
 \usepackage{zed-maths}
 \usepackage{zed-proof}
 \newdimen\savedleftskip

--- a/src/txt2tex/codegen/schemas.py
+++ b/src/txt2tex/codegen/schemas.py
@@ -164,6 +164,11 @@ class _SchemasCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
         Supports optional generic parameters and anonymous schemas (name=None).
         Multiple declarations appear on separate lines with line breaks.
 
+        For schemas with pk-marked fields, uses dual-emit: a fuzz-checked copy
+        inside ``\\setbox0=\\vbox{%…}`` (invisible to LaTeX output) and a
+        rendered copy using the ``schemapk`` environment with
+        ``\\underline{field}`` for each primary-key attribute.
+
         Processes schema names through _generate_identifier() for compound
         identifiers like S+, S*, S~ (partial support, GitHub #3 still open).
         """
@@ -182,24 +187,43 @@ class _SchemasCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
         # Context for overflow warnings
         schema_context = f"schema {schema_name}" if schema_name else "anonymous schema"
 
-        # Add generic parameters if present
+        # Detect PK fields early so we know whether dual-emit is needed.
+        pk_vars: set[str] = set()
+        if node.name is not None:
+            pk_vars = {
+                decl.variable
+                for decl in node.declarations
+                if isinstance(decl, Declaration) and decl.is_primary_key
+            }
+
+        # Build the begin line (reused for both copies when dual-emit).
         if node.generic_params:
             params_str = ", ".join(node.generic_params)
-            lines.append(f"\\begin{{schema}}{{{schema_name}}}[{params_str}]")
+            begin_schema = f"\\begin{{schema}}{{{schema_name}}}[{params_str}]"
+            begin_schemapk = f"\\begin{{schemapk}}{{{schema_name}}}[{params_str}]"
         else:
-            lines.append(r"\begin{schema}{" + schema_name + "}")
+            begin_schema = r"\begin{schema}{" + schema_name + "}"
+            begin_schemapk = r"\begin{schemapk}{" + schema_name + "}"
 
-        # All expression generation inside this block uses Z-paragraph context.
+        # Build declaration and where-clause body lines (shared between copies).
+        # Returns (plain_lines, pk_lines) where pk_lines has \underline on PK vars.
         prev_z = self._in_z_paragraph
         self._in_z_paragraph = True
+        plain_body: list[str] = []
+        pk_body: list[str] = []
         try:
             # Generate declarations on separate lines
             if node.declarations:
                 for i, decl in enumerate(node.declarations):
                     if isinstance(decl, SchemaInclusion):
                         decl_line = self._emit_schema_inclusion(decl)
+                        plain_body.append(
+                            f"{decl_line} \\\\"
+                            if i < len(node.declarations) - 1
+                            else decl_line
+                        )
+                        pk_body.append(plain_body[-1])
                     else:
-                        # Process variable through identifier logic
                         var_latex = self._generate_identifier(
                             Identifier(line=0, column=0, name=decl.variable)
                         )
@@ -217,7 +241,6 @@ class _SchemasCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
                         ]
                         for pattern in special_ops:
                             if pattern in type_latex:
-                                # Find second operator and wrap from there
                                 parts = type_latex.split(pattern, 1)
                                 if len(parts) == 2:
                                     second_part = pattern.split()[-1] + " " + parts[1]
@@ -228,74 +251,64 @@ class _SchemasCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
                                     )
                                     break
 
-                        # Build full declaration line for overflow check
-                        decl_line = f"{var_latex} : {type_latex}"
+                        plain_decl_line = f"{var_latex} : {type_latex}"
                         self._check_overflow(
-                            decl_line,
+                            plain_decl_line,
                             decl.type_expr.line,
                             f"{schema_context} declaration",
                             f"{decl.variable} : ...",
                         )
 
-                    # Add line break after each declaration except the last
-                    if i < len(node.declarations) - 1:
-                        lines.append(f"{decl_line} \\\\")
-                    else:
-                        lines.append(decl_line)
+                        sep = " \\\\" if i < len(node.declarations) - 1 else ""
+                        plain_body.append(f"{plain_decl_line}{sep}")
+
+                        # Wrap identifier in \underline for PK fields
+                        if decl.variable in pk_vars:
+                            pk_var_latex = rf"\underline{{{var_latex}}}"
+                            pk_decl_line = f"{pk_var_latex} : {type_latex}"
+                        else:
+                            pk_decl_line = plain_decl_line
+                        pk_body.append(f"{pk_decl_line}{sep}")
 
             # Generate where clause if predicate groups exist
+            where_lines: list[str] = []
             if node.predicates and any(group for group in node.predicates):
-                lines.append(r"\where")
-
-                # Iterate through predicate groups (separated by blank lines)
+                where_lines.append(r"\where")
                 for group_idx, group in enumerate(node.predicates):
-                    # Generate predicates in current group
                     for pred_idx, pred in enumerate(group):
-                        # Pass parent=None for smart parenthesization
                         pred_latex = self.generate_expr(pred, parent=None)
-
-                        # Auto-wrap long predicates; fall back to warning
                         self._check_overflow(
                             pred_latex,
                             pred.line,
                             f"{schema_context} where clause",
                         )
-
-                        # Use \\ as separator within group
                         if pred_idx < len(group) - 1:
-                            lines.append(f"{pred_latex} \\\\")
+                            where_lines.append(f"{pred_latex} \\\\")
                         else:
-                            lines.append(pred_latex)
-
-                    # Add \also between groups (not after last group)
+                            where_lines.append(pred_latex)
                     if group_idx < len(node.predicates) - 1:
-                        lines.append(r"\also")
+                        where_lines.append(r"\also")
         finally:
             self._in_z_paragraph = prev_z
 
-        lines.append(r"\end{schema}")
-
-        # Emit a fuzz-compatible PK annotation after the schema box.
-        # \underline{} is rejected by fuzz inside schema declaration positions,
-        # so we record the primary-key set as a plain math statement outside
-        # the box: \noindent$\mathrm{PK}(\mathrm{Name}) = \{attr1, attr2\}$
-        # fuzz ignores content outside Z environments; pdflatex renders it.
-        if node.name is not None:
-            pk_attrs = [
-                decl.variable
-                for decl in node.declarations
-                if isinstance(decl, Declaration) and decl.is_primary_key
-            ]
-            if pk_attrs:
-                attrs_str = ", ".join(pk_attrs)
-                lines.append(
-                    rf"\noindent$\mathrm{{PK}}(\mathrm{{{schema_name}}})"
-                    rf" = \{{{attrs_str}\}}$"
-                )
-                # Blank line + \smallskip so the next paragraph (often another
-                # schema) gets visible breathing room from the PK annotation.
-                lines.append("")
-                lines.append(r"\smallskip")
+        if pk_vars:
+            # Dual-emit: fuzz-checked copy inside \setbox (invisible), then
+            # rendered schemapk copy with \underline on PK fields.
+            lines.append(r"\setbox0=\vbox{%")
+            lines.append(begin_schema)
+            lines.extend(plain_body)
+            lines.extend(where_lines)
+            lines.append(r"\end{schema}%")
+            lines.append("}")
+            lines.append(begin_schemapk)
+            lines.extend(pk_body)
+            lines.extend(where_lines)
+            lines.append(r"\end{schemapk}")
+        else:
+            lines.append(begin_schema)
+            lines.extend(plain_body)
+            lines.extend(where_lines)
+            lines.append(r"\end{schema}")
 
         lines.append("")
 

--- a/src/txt2tex/codegen/schemas.py
+++ b/src/txt2tex/codegen/schemas.py
@@ -292,9 +292,9 @@ class _SchemasCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
             self._in_z_paragraph = prev_z
 
         if pk_vars:
-            # Dual-emit: fuzz-checked copy inside \setbox (invisible), then
+            # Dual-emit: fuzz-checked copy inside \savebox (invisible), then
             # rendered schemapk copy with \underline on PK fields.
-            lines.append(r"\setbox0=\vbox{%")
+            lines.append(r"\savebox{\schemapkbox}{%")
             lines.append(begin_schema)
             lines.extend(plain_body)
             lines.extend(where_lines)

--- a/src/txt2tex/latex/schemapk.sty
+++ b/src/txt2tex/latex/schemapk.sty
@@ -1,3 +1,4 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesPackage{schemapk}
+%% Generic params [X,Y] pass through to fuzz.sty's \schema via \@ifnextchar[.
 \newenvironment{schemapk}[1]{\begin{schema}{#1}}{\end{schema}}

--- a/src/txt2tex/latex/schemapk.sty
+++ b/src/txt2tex/latex/schemapk.sty
@@ -1,4 +1,5 @@
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{schemapk}
+\ProvidesPackage{schemapk}[2026/05/27 v1.0 Schema environment with PK underlines]
+\newsavebox{\schemapkbox}
 %% Generic params [X,Y] pass through to fuzz.sty's \schema via \@ifnextchar[.
 \newenvironment{schemapk}[1]{\begin{schema}{#1}}{\end{schema}}

--- a/src/txt2tex/latex/schemapk.sty
+++ b/src/txt2tex/latex/schemapk.sty
@@ -1,0 +1,3 @@
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesPackage{schemapk}
+\newenvironment{schemapk}[1]{\begin{schema}{#1}}{\end{schema}}

--- a/src/txt2tex/latex_gen.py
+++ b/src/txt2tex/latex_gen.py
@@ -408,6 +408,7 @@ class LaTeXGenerator(
             lines.append(r"\usepackage{fuzz}")  # Replaces zed-cm (fonts/styling)
         else:
             lines.append(r"\usepackage{zed-cm}")  # Computer Modern fonts/styling
+        lines.append(r"\usepackage{schemapk}")  # schemapk env for PK underlines
         # These packages work with both fuzz and zed-cm
         lines.append(r"\usepackage{zed-maths}")  # Mathematical operators
         lines.append(r"\usepackage{zed-proof}")  # Proof tree macros (\infer)

--- a/src/txt2tex/repl.py
+++ b/src/txt2tex/repl.py
@@ -118,6 +118,7 @@ def generate_preview_document(latex_fragment: str, *, use_fuzz: bool) -> str:
     else:
         lines.append(r"\usepackage{zed-cm}")
 
+    lines.append(r"\usepackage{schemapk}")
     lines.append(r"\usepackage{zed-maths}")
     lines.append(r"\usepackage{zed-proof}")
     lines.append(r"\newdimen\savedleftskip")

--- a/tests/test_14_relational_databases/test_primary_keys.py
+++ b/tests/test_14_relational_databases/test_primary_keys.py
@@ -3,12 +3,10 @@
 pk is valid only in named schema bodies.  The parser rejects pk in axdef,
 gendef, anonymous schemas, and inline schema text.
 
-For fuzz compatibility the generator does not use \\underline{} inside the
-schema box.  Instead it emits a plain-math PK statement after \\end{schema}:
-
-    \\noindent$\\mathrm{PK}(\\mathrm{Name}) = \\{attr1, attr2\\}$
-
-This sits outside any Z environment so fuzz ignores it; pdflatex renders it.
+For fuzz compatibility the generator uses dual-emit for schemas with PK
+fields: a fuzz-checked copy inside ``\\setbox0=\\vbox{%`` (hidden from
+rendering) and a rendered copy using the ``schemapk`` environment with
+``\\underline{attr}`` for each primary-key field.
 """
 
 from __future__ import annotations
@@ -155,17 +153,18 @@ class TestPKParser:
 
 
 # ---------------------------------------------------------------------------
-# Generator — LaTeX emission (PK line after schema box)
+# Generator — LaTeX emission (underline inside schemapk, setbox fuzz copy)
 # ---------------------------------------------------------------------------
 
 
 class TestPKGenerator:
-    """Generator emits a PK line after the schema box for pk-marked attributes."""
+    """Generator uses dual-emit for PK schemas: setbox fuzz copy + schemapk copy."""
 
-    def test_single_pk_produces_pk_line(self) -> None:
-        r"""pk a : T → PK line after \end{schema}."""
+    def test_single_pk_produces_underline(self) -> None:
+        r"""pk a : T → \underline{a} inside schemapk environment."""
         frag = _fragment("schema S\n  pk a : T\n  b : U\nend")
-        assert r"\mathrm{PK}(\mathrm{S}) = \{a\}" in frag
+        assert r"\underline{a}" in frag
+        assert r"\begin{schemapk}" in frag
 
     def test_plain_declaration_no_pk_line(self) -> None:
         """Schema without pk produces no PK line."""
@@ -173,40 +172,75 @@ class TestPKGenerator:
         assert r"\mathrm{PK}" not in frag
 
     def test_composite_pk_lists_all_attrs(self) -> None:
-        r"""Two pk lines → exactly one PK line listing both attributes."""
+        r"""Two pk lines → both attributes underlined in schemapk."""
         frag = _fragment(
             "schema CentreStaff\n  pk centreId : CentreID\n  pk staffId : PersonID\nend"
         )
-        # Composite PK: one line, both attributes in the set.
-        assert r"\mathrm{PK}(\mathrm{CentreStaff}) = \{centreId, staffId\}" in frag
-        # Exactly one PK statement — not one per attribute.
-        assert frag.count(r"\mathrm{PK}") == 1
+        assert r"\underline{centreId}" in frag
+        assert r"\underline{staffId}" in frag
+
+    def test_plain_schema_no_schemapk(self) -> None:
+        r"""Schema without pk has no schemapk environment or \setbox."""
+        frag = _fragment("schema S\n  b : U\nend")
+        assert r"\begin{schemapk}" not in frag
+        assert r"\setbox0=\vbox" not in frag
+
+    def test_fuzz_copy_inside_setbox(self) -> None:
+        r"""PK schema emits \setbox0=\vbox{%…} wrapping a plain \begin{schema}."""
+        frag = _fragment("schema S\n  pk a : T\nend")
+        assert r"\setbox0=\vbox{%" in frag
+        assert r"\begin{schema}{S}" in frag
+
+    def test_pk_line_removed(self) -> None:
+        r"""Output does not contain \mathrm{PK} annotation."""
+        frag = _fragment("schema S\n  pk a : T\nend")
+        assert r"\mathrm{PK}" not in frag
 
     def test_schema_begin_has_plain_name(self) -> None:
-        r"""\begin{schema}{Class} — schema title is plain (not underlined)."""
+        r"""\begin{schemapk}{Class} — rendered copy uses schemapk."""
         frag = _fragment("schema Class\n  pk class : ClassName\n  type : TypeName\nend")
-        assert r"\begin{schema}{Class}" in frag
+        assert r"\begin{schemapk}{Class}" in frag
 
-    def test_pk_line_contains_only_pk_attrs(self) -> None:
-        """PK set contains only pk-marked attributes, not plain ones."""
+    def test_fuzz_copy_no_underline(self) -> None:
+        r"""The fuzz-checked copy inside \setbox must not contain \underline."""
+        frag = _fragment("schema S\n  pk a : T\nend")
+        setbox_start = frag.find(r"\setbox0=\vbox{%")
+        end_schema = frag.find(r"\end{schema}", setbox_start)
+        # Find the closing brace of the vbox (appears after \end{schema})
+        vbox_end = frag.find("\n}", end_schema)
+        fuzz_copy = frag[setbox_start : vbox_end + 2]
+        assert r"\underline" not in fuzz_copy
+
+    def test_rendered_copy_uses_schemapk_env(self) -> None:
+        r"""Rendered copy opens with \begin{schemapk} and closes with \end{schemapk}."""
+        frag = _fragment("schema S\n  pk a : T\nend")
+        assert r"\begin{schemapk}{S}" in frag
+        assert r"\end{schemapk}" in frag
+
+    def test_pk_only_pk_fields_underlined(self) -> None:
+        r"""Only pk-marked fields are wrapped in \underline; plain fields are not."""
         frag = _fragment("schema S\n  pk a : T\n  b : U\nend")
-        assert "b" not in frag.split(r"\mathrm{PK}")[-1].split(r"\}")[0]
+        assert r"\underline{a}" in frag
+        # b must appear without \underline wrapping
+        assert r"\underline{b}" not in frag
 
-    def test_pk_line_after_end_schema(self) -> None:
-        r"""PK line appears after \end{schema}, not inside the box."""
-        frag = _fragment("schema S\n  pk a : T\nend")
-        end_pos = frag.find(r"\end{schema}")
-        pk_pos = frag.find(r"\mathrm{PK}")
-        assert end_pos >= 0
-        assert pk_pos > end_pos
+    def test_generic_params_duplicated(self) -> None:
+        r"""Schema with generic params: both fuzz copy and schemapk copy carry [X]."""
+        frag = _fragment("schema S[X]\n  pk a : X\nend")
+        assert r"\begin{schema}{S}[X]" in frag
+        assert r"\begin{schemapk}{S}[X]" in frag
 
-    def test_declaration_body_is_plain(self) -> None:
-        r"""pk attribute inside the schema box is plain (no \underline)."""
-        frag = _fragment("schema S\n  pk a : T\nend")
-        assert r"\underline" not in frag
+    def test_two_schemas_each_get_underline(self) -> None:
+        r"""Two pk-annotated schemas each get schemapk environment and underlines."""
+        src = "schema A\n  pk x : N\nend\nschema B\n  pk y : N\nend"
+        frag = _fragment(src)
+        assert r"\begin{schemapk}{A}" in frag
+        assert r"\begin{schemapk}{B}" in frag
+        assert r"\underline{x}" in frag
+        assert r"\underline{y}" in frag
 
     def test_probe_a_class_schema(self) -> None:
-        r"""Probe A: Class schema with pk class — PK line emitted, no \underline."""
+        r"""Probe A: Class schema with pk class — underlined in schemapk."""
         src = (
             "given ClassName, TypeName, CountryName\n"
             "\n"
@@ -220,11 +254,12 @@ class TestPKGenerator:
             "end"
         )
         frag = _fragment(src)
-        assert r"\mathrm{PK}(\mathrm{Class}) = \{class\}" in frag
-        assert r"\underline" not in frag
+        assert r"\begin{schemapk}{Class}" in frag
+        assert r"\underline{class}" in frag
+        assert r"\mathrm{PK}" not in frag
 
     def test_probe_a_ship_schema(self) -> None:
-        r"""Probe A: Ship schema with pk name — PK line lists 'name' only."""
+        r"""Probe A: Ship schema with pk name — underlined in schemapk."""
         src = (
             "given ShipName, ClassName\n"
             "\n"
@@ -235,10 +270,12 @@ class TestPKGenerator:
             "end"
         )
         frag = _fragment(src)
-        assert r"\mathrm{PK}(\mathrm{Ship}) = \{name\}" in frag
+        assert r"\begin{schemapk}{Ship}" in frag
+        assert r"\underline{name}" in frag
+        assert r"\mathrm{PK}" not in frag
 
     def test_probe_b_composite_pk(self) -> None:
-        r"""Probe B: CentreStaff with two pk attributes — both in PK line."""
+        r"""Probe B: CentreStaff with two pk attributes — both underlined."""
         src = (
             "given CentreID, PersonID\n"
             "\n"
@@ -248,20 +285,15 @@ class TestPKGenerator:
             "end"
         )
         frag = _fragment(src)
-        assert r"\mathrm{PK}(\mathrm{CentreStaff}) = \{centreId, staffId\}" in frag
+        assert r"\begin{schemapk}{CentreStaff}" in frag
+        assert r"\underline{centreId}" in frag
+        assert r"\underline{staffId}" in frag
 
     def test_probe_d_pk_fk_as_z_predicates(self) -> None:
         """Probe D: PK/FK as standard Z predicates parse without error."""
         src = "given ClassName\n\naxdef\n  PK : P ClassName\nwhere\n  PK = {class}\nend"
         frag = _fragment(src)
         assert "PK" in frag
-
-    def test_two_schemas_each_get_own_pk_line(self) -> None:
-        """Two pk-annotated schemas each get their own PK line."""
-        src = "schema A\n  pk x : N\nend\nschema B\n  pk y : N\nend"
-        frag = _fragment(src)
-        assert r"\mathrm{PK}(\mathrm{A}) = \{x\}" in frag
-        assert r"\mathrm{PK}(\mathrm{B}) = \{y\}" in frag
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_14_relational_databases/test_primary_keys.py
+++ b/tests/test_14_relational_databases/test_primary_keys.py
@@ -183,12 +183,12 @@ class TestPKGenerator:
         r"""Schema without pk has no schemapk environment or \setbox."""
         frag = _fragment("schema S\n  b : U\nend")
         assert r"\begin{schemapk}" not in frag
-        assert r"\setbox0=\vbox" not in frag
+        assert r"\savebox{\schemapkbox}" not in frag
 
-    def test_fuzz_copy_inside_setbox(self) -> None:
-        r"""PK schema emits \setbox0=\vbox{%…} wrapping a plain \begin{schema}."""
+    def test_fuzz_copy_inside_savebox(self) -> None:
+        r"""PK schema emits \savebox wrapping a plain \begin{schema}."""
         frag = _fragment("schema S\n  pk a : T\nend")
-        assert r"\setbox0=\vbox{%" in frag
+        assert r"\savebox{\schemapkbox}{%" in frag
         assert r"\begin{schema}{S}" in frag
 
     def test_pk_line_removed(self) -> None:
@@ -202,13 +202,12 @@ class TestPKGenerator:
         assert r"\begin{schemapk}{Class}" in frag
 
     def test_fuzz_copy_no_underline(self) -> None:
-        r"""The fuzz-checked copy inside \setbox must not contain \underline."""
+        r"""The fuzz-checked copy inside \savebox must not contain \underline."""
         frag = _fragment("schema S\n  pk a : T\nend")
-        setbox_start = frag.find(r"\setbox0=\vbox{%")
-        end_schema = frag.find(r"\end{schema}", setbox_start)
-        # Find the closing brace of the vbox (appears after \end{schema})
-        vbox_end = frag.find("\n}", end_schema)
-        fuzz_copy = frag[setbox_start : vbox_end + 2]
+        savebox_start = frag.find(r"\savebox{\schemapkbox}{%")
+        end_schema = frag.find(r"\end{schema}", savebox_start)
+        box_end = frag.find("\n}", end_schema)
+        fuzz_copy = frag[savebox_start : box_end + 2]
         assert r"\underline" not in fuzz_copy
 
     def test_rendered_copy_uses_schemapk_env(self) -> None:
@@ -223,6 +222,13 @@ class TestPKGenerator:
         assert r"\underline{a}" in frag
         # b must appear without \underline wrapping
         assert r"\underline{b}" not in frag
+
+    def test_comma_separated_pk_both_underlined(self) -> None:
+        r"""pk a, b : T — both names underlined independently."""
+        frag = _fragment("schema S\n  pk a, b : T\nend")
+        assert r"\underline{a}" in frag
+        assert r"\underline{b}" in frag
+        assert r"\begin{schemapk}{S}" in frag
 
     def test_generic_params_duplicated(self) -> None:
         r"""Schema with generic params: both fuzz copy and schemapk copy carry [X]."""


### PR DESCRIPTION
## Summary

- PK-marked schema fields now render with `\underline{field}` inside the schema box, matching the instructor's format
- Uses dual-emit: fuzz type-checks a hidden plain copy (`\setbox0=\vbox{...}`); pdflatex renders a `schemapk` copy with underlines
- Removes the old `\mathrm{PK}(Name) = {...}` annotation line below the box
- Adds `schemapk.sty` (auto-bundled by existing `glob("*.sty")`)
- Compound PKs underline each field independently

## Test plan

- [x] `make check` — 4726 passed, 1 xfail, 0 errors
- [x] `make test-e2e` — 159/159 byte-identical after fixture regen
- [x] `fuzz -t` confirms schemas are type-checked (bookId: NN, isbn: NN, etc.)
- [x] PDF visual inspection — underlined PK fields, no duplicate schemas
- [x] djb security review (pending)
- [x] ghr docs review — all findings addressed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core schema LaTeX generation and fuzz interaction for all `pk` schemas; regression coverage is strong but PDF/fuzz behavior must stay aligned.
> 
> **Overview**
> **Primary keys** now show as underlined attribute names inside the schema box (`\underline{field}`), replacing the separate `\mathrm{PK}(Name) = \{...\}` line below the box.
> 
> For schemas with `pk` fields, the generator **dual-emits** LaTeX: a plain `\begin{schema}...\end{schema}` copy inside `\savebox{\schemapkbox}{...}` so fuzz still type-checks identifiers, plus a visible `\begin{schemapk}...\end{schemapk}` copy with underlines (fuzz ignores `schemapk`). Schemas without PK fields are unchanged.
> 
> Adds bundled **`schemapk.sty`**, wires `\usepackage{schemapk}` in document preambles (`latex_gen.py`, `repl.py`), and refreshes docs, changelog, primary-key tests, and regenerated example `.tex` fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34ecab54e7c7ed4ef23e1c60f4a1eb5b8cd0ead0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->