### PR TITLE
chore(release): v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-05-27
+
 ### Changed
 
 - **PK fields rendered with underline** — primary-key attributes

--- a/examples/11_text_blocks/bibliography_example.tex
+++ b/examples/11_text_blocks/bibliography_example.tex
@@ -12,7 +12,7 @@
 \title{Bibliography Example}
 \author{Example Author}
 \date{2025}
-\hypersetup{pdftitle={Bibliography Example},pdfauthor={Example Author},pdfcreator={txt2tex v1.5.0}}
+\hypersetup{pdftitle={Bibliography Example},pdfauthor={Example Author},pdfcreator={txt2tex v1.6.0}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/algebra_basics.tex
+++ b/examples/14_relational_databases/algebra_basics.tex
@@ -11,7 +11,7 @@
 \newdimen\savedleftskip
 \title{Relational Algebra}
 \author{txt2tex example}
-\hypersetup{pdftitle={Relational Algebra},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.5.0}}
+\hypersetup{pdftitle={Relational Algebra},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.0}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/bindings.tex
+++ b/examples/14_relational_databases/bindings.tex
@@ -11,7 +11,7 @@
 \newdimen\savedleftskip
 \title{Z Binding Calculus}
 \author{txt2tex example}
-\hypersetup{pdftitle={Z Binding Calculus},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.5.0}}
+\hypersetup{pdftitle={Z Binding Calculus},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.0}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/foreign_keys.tex
+++ b/examples/14_relational_databases/foreign_keys.tex
@@ -11,7 +11,7 @@
 \newdimen\savedleftskip
 \title{Foreign Keys in Relational Schemas}
 \author{txt2tex example}
-\hypersetup{pdftitle={Foreign Keys in Relational Schemas},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.5.0}}
+\hypersetup{pdftitle={Foreign Keys in Relational Schemas},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.0}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/group_ungroup.tex
+++ b/examples/14_relational_databases/group_ungroup.tex
@@ -11,7 +11,7 @@
 \newdimen\savedleftskip
 \title{GROUP and UNGROUP}
 \author{txt2tex example}
-\hypersetup{pdftitle={GROUP and UNGROUP},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.5.0}}
+\hypersetup{pdftitle={GROUP and UNGROUP},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.0}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/normalisation.tex
+++ b/examples/14_relational_databases/normalisation.tex
@@ -11,7 +11,7 @@
 \newdimen\savedleftskip
 \title{Functional Dependencies and Normalisation}
 \author{txt2tex example}
-\hypersetup{pdftitle={Functional Dependencies and Normalisation},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.5.0}}
+\hypersetup{pdftitle={Functional Dependencies and Normalisation},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.0}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/primary_keys.tex
+++ b/examples/14_relational_databases/primary_keys.tex
@@ -11,7 +11,7 @@
 \newdimen\savedleftskip
 \title{Primary Keys in Relational Schemas}
 \author{txt2tex example}
-\hypersetup{pdftitle={Primary Keys in Relational Schemas},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.5.0}}
+\hypersetup{pdftitle={Primary Keys in Relational Schemas},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.0}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/relational_calculus.tex
+++ b/examples/14_relational_databases/relational_calculus.tex
@@ -11,7 +11,7 @@
 \newdimen\savedleftskip
 \title{Relational Calculus --- Music Library}
 \author{txt2tex example}
-\hypersetup{pdftitle={Relational Calculus --- Music Library},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.5.0}}
+\hypersetup{pdftitle={Relational Calculus --- Music Library},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.0}}
 \begin{document}
 
 \maketitle

--- a/examples/16_multi_decl_calculus/q2d_demo.tex
+++ b/examples/16_multi_decl_calculus/q2d_demo.tex
@@ -11,7 +11,7 @@
 \newdimen\savedleftskip
 \title{Multi-Declaration Z Constructs --- Demo}
 \author{txt2tex}
-\hypersetup{pdftitle={Multi-Declaration Z Constructs --- Demo},pdfauthor={txt2tex},pdfcreator={txt2tex v1.5.0}}
+\hypersetup{pdftitle={Multi-Declaration Z Constructs --- Demo},pdfauthor={txt2tex},pdfcreator={txt2tex v1.6.0}}
 \begin{document}
 
 \maketitle

--- a/src/txt2tex/__version__.py
+++ b/src/txt2tex/__version__.py
@@ -1,3 +1,3 @@
 """Defines the version of the txt2tex package."""
 
-__version__ = "1.5.0"
+__version__ = "1.6.0"


### PR DESCRIPTION
## Summary

- Bump version to 1.6.0
- Move Unreleased CHANGELOG entries to [1.6.0] section
- Regenerate 9 .tex fixtures (version string in pdfcreator only)

## What's in 1.6.0

- **PK fields rendered with underline** — `\underline{field}` inside schema box via dual-emit technique

## Test plan

- [x] `make check` — 4727 passed, 1 xfail
- [x] `make test-e2e` — 159/159 after fixture regen (all diffs are version-string only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, version constant, and metadata-only fixture updates; no runtime or rendering logic changes in the diff.
> 
> **Overview**
> Release **v1.6.0**: bumps `__version__` to **1.6.0**, adds a dated **[1.6.0]** section in `CHANGELOG.md` (moving the unreleased note about **PK fields underlined in schema boxes** via dual-emit `schemapk`), and refreshes **nine** example `.tex` fixtures so `hypersetup` `pdfcreator` reads `txt2tex v1.6.0`. No parser or generator logic changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f95ec3862699f7a12081b0ec4a28d2d501c4e721. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->