### PR TITLE
fix(codegen): revert savebox to setbox0 vbox for PK dual-emit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.1] - 2026-05-27
+
+### Fixed
+
+- **PK dual-emit compilation failure** — `\savebox` (which creates an
+  `\hbox`) broke fuzz.sty's `\halign` inside the schema environment.
+  Reverted to `\setbox0=\vbox{%}` which provides the correct context
+  for alignment-based environments.
+
 ## [1.6.0] - 2026-05-27
 
 ### Changed

--- a/examples/11_text_blocks/bibliography_example.tex
+++ b/examples/11_text_blocks/bibliography_example.tex
@@ -12,7 +12,7 @@
 \title{Bibliography Example}
 \author{Example Author}
 \date{2025}
-\hypersetup{pdftitle={Bibliography Example},pdfauthor={Example Author},pdfcreator={txt2tex v1.6.0}}
+\hypersetup{pdftitle={Bibliography Example},pdfauthor={Example Author},pdfcreator={txt2tex v1.6.1}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/algebra_basics.tex
+++ b/examples/14_relational_databases/algebra_basics.tex
@@ -11,7 +11,7 @@
 \newdimen\savedleftskip
 \title{Relational Algebra}
 \author{txt2tex example}
-\hypersetup{pdftitle={Relational Algebra},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.0}}
+\hypersetup{pdftitle={Relational Algebra},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.1}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/bindings.tex
+++ b/examples/14_relational_databases/bindings.tex
@@ -11,7 +11,7 @@
 \newdimen\savedleftskip
 \title{Z Binding Calculus}
 \author{txt2tex example}
-\hypersetup{pdftitle={Z Binding Calculus},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.0}}
+\hypersetup{pdftitle={Z Binding Calculus},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.1}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/foreign_keys.tex
+++ b/examples/14_relational_databases/foreign_keys.tex
@@ -11,7 +11,7 @@
 \newdimen\savedleftskip
 \title{Foreign Keys in Relational Schemas}
 \author{txt2tex example}
-\hypersetup{pdftitle={Foreign Keys in Relational Schemas},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.0}}
+\hypersetup{pdftitle={Foreign Keys in Relational Schemas},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.1}}
 \begin{document}
 
 \maketitle
@@ -26,7 +26,7 @@
 
 \bigskip
 
-\savebox{\schemapkbox}{%
+\setbox0=\vbox{%
 \begin{schema}{Recipe}
 recipeId : RecipeId \\
 name : RecipeName \\
@@ -39,7 +39,7 @@ name : RecipeName \\
 cuisine : CuisineTag
 \end{schemapk}
 
-\savebox{\schemapkbox}{%
+\setbox0=\vbox{%
 \begin{schema}{Ingredient}
 ingredientId : IngredientId \\
 name : IngredientName
@@ -58,7 +58,7 @@ name : IngredientName
 
 \bigskip
 
-\savebox{\schemapkbox}{%
+\setbox0=\vbox{%
 \begin{schema}{RecipeIngredient}
 recipeId : RecipeId \\
 ingredientId : IngredientId
@@ -119,7 +119,7 @@ $\forall ri : RecipeIngredient @ \exists i : Ingredient @ ri.ingredientId = i.in
 
 \bigskip
 
-\savebox{\schemapkbox}{%
+\setbox0=\vbox{%
 \begin{schema}{Employee}
 employeeId : EmployeeId \\
 name : EmployeeName \\

--- a/examples/14_relational_databases/group_ungroup.tex
+++ b/examples/14_relational_databases/group_ungroup.tex
@@ -11,7 +11,7 @@
 \newdimen\savedleftskip
 \title{GROUP and UNGROUP}
 \author{txt2tex example}
-\hypersetup{pdftitle={GROUP and UNGROUP},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.0}}
+\hypersetup{pdftitle={GROUP and UNGROUP},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.1}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/normalisation.tex
+++ b/examples/14_relational_databases/normalisation.tex
@@ -11,7 +11,7 @@
 \newdimen\savedleftskip
 \title{Functional Dependencies and Normalisation}
 \author{txt2tex example}
-\hypersetup{pdftitle={Functional Dependencies and Normalisation},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.0}}
+\hypersetup{pdftitle={Functional Dependencies and Normalisation},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.1}}
 \begin{document}
 
 \maketitle
@@ -24,7 +24,7 @@
 
 \bigskip
 
-\savebox{\schemapkbox}{%
+\setbox0=\vbox{%
 \begin{schema}{Universal}
 empID : EmpID \\
 empName : EmpName \\
@@ -127,7 +127,7 @@ projName : ProjName
 
 \bigskip
 
-\savebox{\schemapkbox}{%
+\setbox0=\vbox{%
 \begin{schema}{Employee}
 empID : EmpID \\
 empName : EmpName \\
@@ -140,7 +140,7 @@ empName : EmpName \\
 dept : DeptName
 \end{schemapk}
 
-\savebox{\schemapkbox}{%
+\setbox0=\vbox{%
 \begin{schema}{Department}
 dept : DeptName \\
 deptHead : HeadName
@@ -151,7 +151,7 @@ deptHead : HeadName
 deptHead : HeadName
 \end{schemapk}
 
-\savebox{\schemapkbox}{%
+\setbox0=\vbox{%
 \begin{schema}{Project}
 projID : ProjID \\
 projName : ProjName
@@ -162,7 +162,7 @@ projName : ProjName
 projName : ProjName
 \end{schemapk}
 
-\savebox{\schemapkbox}{%
+\setbox0=\vbox{%
 \begin{schema}{Assignment}
 empID : EmpID \\
 projID : ProjID

--- a/examples/14_relational_databases/primary_keys.tex
+++ b/examples/14_relational_databases/primary_keys.tex
@@ -11,7 +11,7 @@
 \newdimen\savedleftskip
 \title{Primary Keys in Relational Schemas}
 \author{txt2tex example}
-\hypersetup{pdftitle={Primary Keys in Relational Schemas},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.0}}
+\hypersetup{pdftitle={Primary Keys in Relational Schemas},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.1}}
 \begin{document}
 
 \maketitle
@@ -20,7 +20,7 @@
 
 \section*{Single Primary Key}
 
-\savebox{\schemapkbox}{%
+\setbox0=\vbox{%
 \begin{schema}{Book}
 bookId : BookId \\
 isbn : ISBN \\
@@ -35,7 +35,7 @@ pages : \nat \\
 year : \nat
 \end{schemapk}
 
-\savebox{\schemapkbox}{%
+\setbox0=\vbox{%
 \begin{schema}{Member}
 memberId : MemberId \\
 age : \nat
@@ -46,7 +46,7 @@ age : \nat
 age : \nat
 \end{schemapk}
 
-\savebox{\schemapkbox}{%
+\setbox0=\vbox{%
 \begin{schema}{Loan}
 loanId : LoanId \\
 bookId : BookId \\
@@ -63,7 +63,7 @@ daysOut : \nat
 
 \section*{Composite Primary Key}
 
-\savebox{\schemapkbox}{%
+\setbox0=\vbox{%
 \begin{schema}{LoanHistory}
 bookId : BookId \\
 memberId : MemberId

--- a/examples/14_relational_databases/relational_calculus.tex
+++ b/examples/14_relational_databases/relational_calculus.tex
@@ -11,7 +11,7 @@
 \newdimen\savedleftskip
 \title{Relational Calculus --- Music Library}
 \author{txt2tex example}
-\hypersetup{pdftitle={Relational Calculus --- Music Library},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.0}}
+\hypersetup{pdftitle={Relational Calculus --- Music Library},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.1}}
 \begin{document}
 
 \maketitle

--- a/examples/16_multi_decl_calculus/q2d_demo.tex
+++ b/examples/16_multi_decl_calculus/q2d_demo.tex
@@ -11,7 +11,7 @@
 \newdimen\savedleftskip
 \title{Multi-Declaration Z Constructs --- Demo}
 \author{txt2tex}
-\hypersetup{pdftitle={Multi-Declaration Z Constructs --- Demo},pdfauthor={txt2tex},pdfcreator={txt2tex v1.6.0}}
+\hypersetup{pdftitle={Multi-Declaration Z Constructs --- Demo},pdfauthor={txt2tex},pdfcreator={txt2tex v1.6.1}}
 \begin{document}
 
 \maketitle
@@ -26,7 +26,7 @@
 
 \medskip
 
-\savebox{\schemapkbox}{%
+\setbox0=\vbox{%
 \begin{schema}{Tournament}
 tournamentId : TournamentId \\
 venue : VenueName \\
@@ -43,7 +43,7 @@ tier : \nat
 tier \leq 5
 \end{schemapk}
 
-\savebox{\schemapkbox}{%
+\setbox0=\vbox{%
 \begin{schema}{Player}
 name : PlayerName \\
 ranking : \nat
@@ -54,7 +54,7 @@ ranking : \nat
 ranking : \nat
 \end{schemapk}
 
-\savebox{\schemapkbox}{%
+\setbox0=\vbox{%
 \begin{schema}{Match}
 matchId : MatchId \\
 tournament : TournamentId \\

--- a/src/txt2tex/__version__.py
+++ b/src/txt2tex/__version__.py
@@ -1,3 +1,3 @@
 """Defines the version of the txt2tex package."""
 
-__version__ = "1.6.0"
+__version__ = "1.6.1"

--- a/src/txt2tex/codegen/schemas.py
+++ b/src/txt2tex/codegen/schemas.py
@@ -292,9 +292,11 @@ class _SchemasCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
             self._in_z_paragraph = prev_z
 
         if pk_vars:
-            # Dual-emit: fuzz-checked copy inside \savebox (invisible), then
+            # Dual-emit: fuzz-checked copy inside \vbox (invisible), then
             # rendered schemapk copy with \underline on PK fields.
-            lines.append(r"\savebox{\schemapkbox}{%")
+            # Must use \setbox0=\vbox, not \savebox — fuzz.sty's schema
+            # environment uses \halign which requires a \vbox context.
+            lines.append(r"\setbox0=\vbox{%")
             lines.append(begin_schema)
             lines.extend(plain_body)
             lines.extend(where_lines)

--- a/src/txt2tex/latex/schemapk.sty
+++ b/src/txt2tex/latex/schemapk.sty
@@ -1,5 +1,4 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesPackage{schemapk}[2026/05/27 v1.0 Schema environment with PK underlines]
-\newsavebox{\schemapkbox}
 %% Generic params [X,Y] pass through to fuzz.sty's \schema via \@ifnextchar[.
 \newenvironment{schemapk}[1]{\begin{schema}{#1}}{\end{schema}}

--- a/tests/test_14_relational_databases/test_primary_keys.py
+++ b/tests/test_14_relational_databases/test_primary_keys.py
@@ -183,12 +183,12 @@ class TestPKGenerator:
         r"""Schema without pk has no schemapk environment or \setbox."""
         frag = _fragment("schema S\n  b : U\nend")
         assert r"\begin{schemapk}" not in frag
-        assert r"\savebox{\schemapkbox}" not in frag
+        assert r"\setbox0=\vbox" not in frag
 
     def test_fuzz_copy_inside_savebox(self) -> None:
         r"""PK schema emits \savebox wrapping a plain \begin{schema}."""
         frag = _fragment("schema S\n  pk a : T\nend")
-        assert r"\savebox{\schemapkbox}{%" in frag
+        assert r"\setbox0=\vbox{%" in frag
         assert r"\begin{schema}{S}" in frag
 
     def test_pk_line_removed(self) -> None:
@@ -204,7 +204,7 @@ class TestPKGenerator:
     def test_fuzz_copy_no_underline(self) -> None:
         r"""The fuzz-checked copy inside \savebox must not contain \underline."""
         frag = _fragment("schema S\n  pk a : T\nend")
-        savebox_start = frag.find(r"\savebox{\schemapkbox}{%")
+        savebox_start = frag.find(r"\setbox0=\vbox{%")
         end_schema = frag.find(r"\end{schema}", savebox_start)
         box_end = frag.find("\n}", end_schema)
         fuzz_copy = frag[savebox_start : box_end + 2]


### PR DESCRIPTION
## Summary

- `\savebox` creates an `\hbox` internally, breaking fuzz.sty's `\halign` inside schema environments (! Missing \endgroup inserted)
- Reverts to `\setbox0=\vbox{%}` which provides the correct alignment context
- Removes unused `\newsavebox` from `schemapk.sty`
- Bumps version to 1.6.1 (patch release for broken 1.6.0)

## Test plan

- [x] `make check` — 4727 passed, 1 xfail
- [x] Manual: `txt2tex solutions-jmf.txt` in course-ox-dat compiles to PDF successfully
- [x] `fuzz -t` confirms schemas are type-checked

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted LaTeX emission fix and regenerated examples; behavior for non-PK schemas is unchanged.
> 
> **Overview**
> **Patch release 1.6.1** fixes LaTeX compilation for schemas with `pk` primary keys introduced in 1.6.0.
> 
> The hidden fuzz type-check copy in PK **dual-emit** no longer uses `\savebox{\schemapkbox}` (an `\hbox`), which broke fuzz.sty's `\halign` inside `schema`. Codegen now emits `\setbox0=\vbox{%` … `}` around the plain `\begin{schema}` copy; the visible `\begin{schemapk}` block with `\underline` PK fields is unchanged. **`schemapk.sty`** drops the unused `\newsavebox{\schemapkbox}`. Example `.tex` outputs and primary-key tests are updated to match; `pdfcreator` metadata moves to v1.6.1.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc2a0054ecdc68bcb3fa4c200cabb018ff101840. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->