### PR TITLE
chore(release): v1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.2] - 2026-05-27
+
+### Fixed
+
+- **`F`/`P` as abbreviation names** — `F == expr` and `P == expr`
+  no longer fail; the parser now recognizes FINSET/POWER tokens
+  followed by `==` as abbreviation definitions.
+- **Paren-free `sigma` and `pi`** — `sigma[p]R` and `pi[a,b]R`
+  now parse without requiring parentheses around the relation.
+- **Rename on compound expressions** — `(S join T)[a/x]` and
+  `sigma[p](R)[a/x]` now parse as relation renames.
+- **Better error for unspaced `>` `<` in `sigma[...]`** — error
+  message now suggests adding spaces instead of the cryptic
+  "Expected ']' after sigma predicate".
+
 ## [1.6.1] - 2026-05-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **`F`/`P` as abbreviation names** — `F == expr` and `P == expr`
-  no longer fail; the parser now recognizes FINSET/POWER tokens
+  no longer fail; the parser now recognizes `FINSET`/`POWER` tokens
   followed by `==` as abbreviation definitions.
 - **Paren-free `sigma` and `pi`** — `sigma[p]R` and `pi[a,b]R`
   now parse without requiring parentheses around the relation.

--- a/examples/11_text_blocks/bibliography_example.tex
+++ b/examples/11_text_blocks/bibliography_example.tex
@@ -12,7 +12,7 @@
 \title{Bibliography Example}
 \author{Example Author}
 \date{2025}
-\hypersetup{pdftitle={Bibliography Example},pdfauthor={Example Author},pdfcreator={txt2tex v1.6.1}}
+\hypersetup{pdftitle={Bibliography Example},pdfauthor={Example Author},pdfcreator={txt2tex v1.6.2}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/algebra_basics.tex
+++ b/examples/14_relational_databases/algebra_basics.tex
@@ -11,7 +11,7 @@
 \newdimen\savedleftskip
 \title{Relational Algebra}
 \author{txt2tex example}
-\hypersetup{pdftitle={Relational Algebra},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.1}}
+\hypersetup{pdftitle={Relational Algebra},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.2}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/bindings.tex
+++ b/examples/14_relational_databases/bindings.tex
@@ -11,7 +11,7 @@
 \newdimen\savedleftskip
 \title{Z Binding Calculus}
 \author{txt2tex example}
-\hypersetup{pdftitle={Z Binding Calculus},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.1}}
+\hypersetup{pdftitle={Z Binding Calculus},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.2}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/foreign_keys.tex
+++ b/examples/14_relational_databases/foreign_keys.tex
@@ -11,7 +11,7 @@
 \newdimen\savedleftskip
 \title{Foreign Keys in Relational Schemas}
 \author{txt2tex example}
-\hypersetup{pdftitle={Foreign Keys in Relational Schemas},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.1}}
+\hypersetup{pdftitle={Foreign Keys in Relational Schemas},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.2}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/group_ungroup.tex
+++ b/examples/14_relational_databases/group_ungroup.tex
@@ -11,7 +11,7 @@
 \newdimen\savedleftskip
 \title{GROUP and UNGROUP}
 \author{txt2tex example}
-\hypersetup{pdftitle={GROUP and UNGROUP},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.1}}
+\hypersetup{pdftitle={GROUP and UNGROUP},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.2}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/normalisation.tex
+++ b/examples/14_relational_databases/normalisation.tex
@@ -11,7 +11,7 @@
 \newdimen\savedleftskip
 \title{Functional Dependencies and Normalisation}
 \author{txt2tex example}
-\hypersetup{pdftitle={Functional Dependencies and Normalisation},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.1}}
+\hypersetup{pdftitle={Functional Dependencies and Normalisation},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.2}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/primary_keys.tex
+++ b/examples/14_relational_databases/primary_keys.tex
@@ -11,7 +11,7 @@
 \newdimen\savedleftskip
 \title{Primary Keys in Relational Schemas}
 \author{txt2tex example}
-\hypersetup{pdftitle={Primary Keys in Relational Schemas},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.1}}
+\hypersetup{pdftitle={Primary Keys in Relational Schemas},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.2}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/relational_calculus.tex
+++ b/examples/14_relational_databases/relational_calculus.tex
@@ -11,7 +11,7 @@
 \newdimen\savedleftskip
 \title{Relational Calculus --- Music Library}
 \author{txt2tex example}
-\hypersetup{pdftitle={Relational Calculus --- Music Library},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.1}}
+\hypersetup{pdftitle={Relational Calculus --- Music Library},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.2}}
 \begin{document}
 
 \maketitle

--- a/examples/16_multi_decl_calculus/q2d_demo.tex
+++ b/examples/16_multi_decl_calculus/q2d_demo.tex
@@ -11,7 +11,7 @@
 \newdimen\savedleftskip
 \title{Multi-Declaration Z Constructs --- Demo}
 \author{txt2tex}
-\hypersetup{pdftitle={Multi-Declaration Z Constructs --- Demo},pdfauthor={txt2tex},pdfcreator={txt2tex v1.6.1}}
+\hypersetup{pdftitle={Multi-Declaration Z Constructs --- Demo},pdfauthor={txt2tex},pdfcreator={txt2tex v1.6.2}}
 \begin{document}
 
 \maketitle

--- a/src/txt2tex/__version__.py
+++ b/src/txt2tex/__version__.py
@@ -1,3 +1,3 @@
 """Defines the version of the txt2tex package."""
 
-__version__ = "1.6.1"
+__version__ = "1.6.2"


### PR DESCRIPTION
## Summary

- Bump version to 1.6.2
- Update CHANGELOG with four parser fixes from PR #61
- Update fixture .tex version stamps

## Test plan

- [ ] `make check` passes
- [ ] Version string is 1.6.2 everywhere

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release housekeeping only—version string, changelog, and example .tex metadata—with no parser or generator code in the diff.
> 
> **Overview**
> Release **v1.6.2**: bumps the package version from **1.6.1** to **1.6.2** in `__version__.py` and refreshes generated example PDF metadata (`pdfcreator` in `\hypersetup`) to match.
> 
> **CHANGELOG** adds the **1.6.2** section (dated 2026-05-27) documenting four parser fixes shipped with this release (from PR #61): `F`/`P` abbreviation definitions, parenthesis-free `sigma`/`pi`, renames on compound expressions, and clearer errors for unspaced `>`/`<` inside `sigma[...]` predicates. No application logic changes appear in this diff—only versioning, release notes, and fixture stamps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 795e3ac7a2b05e99af91c90972606f56918920c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->