### PR TITLE
feat(codegen): dual-emit fuzz validation for set comprehensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Dual-emit fuzz validation for set comprehensions** — set
+  comprehensions with binding characteristic expressions (`{| a == e1 |}`)
+  are now fuzz-validated via a hidden copy that converts bindings to
+  tuples.  Standalone set comprehensions (not wrapped in abbreviations)
+  are also validated via synthetic abbreviations (`zS_1`, `zS_2`, ...).
+  Previously, both cases bypassed fuzz entirely.
+
 ## [1.6.2] - 2026-05-27
 
 ### Fixed

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -2907,3 +2907,68 @@ jms ruling (2026-05-23):
   inline math; fuzz never processed them).
 - 6 new parser tests (`TestRelationRenameParser`) and 2 generator tests
   (`TestRelationRenameGenerator`) in `test_algebra.py` cover the new form.
+
+## ADR: Dual-emit fuzz validation for set comprehensions with bindings
+
+**Context.**  Binding literals (`{| a == e1, b == e2 |}`) are not part
+of fuzz's Z grammar — fuzz rejects `==` inside a binding bracket.  Set
+comprehensions whose characteristic expression is a binding therefore
+route to inline math (`\noindent$...$`), which fuzz silently skips.
+This means fuzz never validates the types of the variables, domain, or
+predicate in these expressions.  Standalone set comprehensions (not
+wrapped in an abbreviation) also escape fuzz validation because fuzz
+only accepts abbreviations inside `\begin{zed}...\end{zed}`, not bare
+expressions.  The PK underline dual-emit pattern (this document, "ADR:
+pk Primary-Key Underline via Dual-Emit") established the technique of
+emitting a hidden fuzz-valid copy inside `\setbox0=\vbox{%...}` and a
+visible PDF copy.
+
+**Decision.**  Two orthogonal transforms, applied at LaTeX generation
+time:
+
+1. **Synthetic abbreviation wrapping.**  Any standalone set
+   comprehension (not already the RHS of an abbreviation) is assigned
+   a synthetic name (`zS_1`, `zS_2`, ...) and emitted as a hidden
+   `\setbox0=\vbox{\begin{zed}zS_N == ...\end{zed}}` before the
+   visible inline-math copy.  fuzz validates the hidden abbreviation;
+   pdflatex discards the box.
+
+2. **Binding-to-tuple conversion.**  When a set comprehension's
+   characteristic expression is a `Binding` node, the hidden fuzz copy
+   replaces it with the equivalent tuple: single-field `{| a == e1 |}`
+   becomes `e1`; multi-field `{| a == e1, b == e2 |}` becomes
+   `(e1, e2)`.  The visible copy keeps the binding intact.
+
+fuzz's `\begin{zed}` parser does not accept `\begin{array}` (used for
+WYSIWYG line breaks in set comprehensions).  The `_in_hidden_fuzz_block`
+flag suppresses this wrapping inside hidden copies.
+
+Synthetic names use the prefix `zS_` (verified to be valid fuzz
+identifiers; the alternative `\_S` was rejected — fuzz treats `\_` as
+a syntax error).
+
+**Implementation.**  `codegen/fuzz_routing.py` (binding-to-tuple,
+hidden-emit helpers), `codegen/paragraphs.py` (abbreviation dual-emit),
+`codegen/_dispatch.py` (standalone set comp dual-emit),
+`codegen/expressions.py` (`_in_hidden_fuzz_block` check).
+
+**Rejected alternatives.**
+
+1. *Modify fuzz to accept bindings.* Not feasible — fuzz is an
+   external tool we do not maintain.
+
+2. *Only validate abbreviations, not standalone expressions.*
+   Standalone set comprehensions in exercise solutions are common;
+   leaving them unvalidated defeats the purpose.
+
+**Consequences.**
+
+- Set comprehensions with bindings are now fuzz-validated via the
+  tuple-equivalent hidden copy.  Type errors in declarations,
+  predicates, and field projections are caught.
+- Standalone set comprehensions are fuzz-validated via synthetic
+  abbreviations.  Previously they had no fuzz coverage.
+- The synthetic abbreviation names (`zS_1`, `zS_2`, ...) appear in
+  `fuzz -t` output but are invisible in the PDF.
+- 14 new tests in `test_set_comp_fuzz_validation.py` cover all four
+  cases (standalone ± binding, abbreviation ± binding).

--- a/src/txt2tex/codegen/_dispatch.py
+++ b/src/txt2tex/codegen/_dispatch.py
@@ -18,10 +18,15 @@ from collections.abc import Callable
 from functools import singledispatchmethod
 from typing import TYPE_CHECKING, ClassVar, TypeVar, cast
 
-from txt2tex.ast_nodes import DocumentItem, Expr
+from txt2tex.ast_nodes import Binding, DocumentItem, Expr, SetComprehension
 
 if TYPE_CHECKING:
-    from txt2tex.ast_nodes import BinaryOp, Identifier, Quantifier, SchemaInclusion
+    from txt2tex.ast_nodes import (
+        BinaryOp,
+        Identifier,
+        Quantifier,
+        SchemaInclusion,
+    )
 
 F = TypeVar("F", bound=Callable[..., object])
 
@@ -65,6 +70,8 @@ class CodegenDispatch:
         _first_part_in_solution: bool
         _in_argue_block: bool
         _dollar_sanitise_registry: dict[str, str]
+        _synth_abbrev_counter: int
+        _in_hidden_fuzz_block: bool
         parts_format: str
         toc_parts: bool
         use_fuzz: bool
@@ -108,6 +115,14 @@ class CodegenDispatch:
             self, items: list[DocumentItem]
         ) -> list[str]: ...
         def _emit_attr_name(self, name: str) -> str: ...
+        def _next_synth_name(self) -> str: ...
+        def _binding_to_tuple_expr(self, binding: Binding) -> Expr: ...
+        def _replace_binding_with_tuple(
+            self, node: SetComprehension
+        ) -> SetComprehension: ...
+        def _emit_hidden_abbreviation(
+            self, name_latex: str, expr: Expr
+        ) -> list[str]: ...
 
     @singledispatchmethod
     def generate_document_item(self, item: DocumentItem) -> list[str]:
@@ -126,31 +141,38 @@ class CodegenDispatch:
         """
         # Fallback only reached for Expr types (all document types are registered)
         expr = cast("Expr", item)
+
+        # Standalone set comprehension in fuzz mode: emit a hidden synthetic
+        # abbreviation for fuzz validation before the visible inline-math copy.
+        if self.use_fuzz and isinstance(expr, SetComprehension):
+            hidden_expr = self._replace_binding_with_tuple(expr)
+            synth_name = self._next_synth_name()
+            hidden_lines = self._emit_hidden_abbreviation(synth_name, hidden_expr)
+            return hidden_lines + self._generate_expr_document_item(expr)
+
+        return self._generate_expr_document_item(expr)
+
+    def _generate_expr_document_item(self, expr: Expr) -> list[str]:
+        """Emit the visible inline-math lines for an expression document item."""
         latex_expr = self.generate_expr(expr)
 
         if self._has_line_breaks(expr):
-            # Multi-line expression: use display math with array
-            # Respect inline part context for proper positioning
             lines: list[str] = []
 
             if self._in_inline_part:
-                # Inside part with leftskip: position naturally with leftskip
                 lines.append(r"\savedleftskip=\leftskip")
                 lines.append(r"\noindent")
             else:
-                # Normal context: just prevent paragraph indentation
                 lines.append(r"\noindent")
 
             lines.append(r"$\displaystyle")
-            lines.append(r"\begin{array}{l}")  # Left-aligned single column
+            lines.append(r"\begin{array}{l}")
             lines.append(latex_expr)
             lines.append(r"\end{array}$")
             lines.append("")
-            # Add trailing spacing for separation from following content
             lines.append(r"\bigskip")
             lines.append("")
             return lines
-        # Single-line expression: use inline math (original behavior)
         return [r"\noindent", f"${latex_expr}$", "", ""]
 
     @singledispatchmethod

--- a/src/txt2tex/codegen/_dispatch.py
+++ b/src/txt2tex/codegen/_dispatch.py
@@ -144,11 +144,14 @@ class CodegenDispatch:
 
         # Standalone set comprehension in fuzz mode: emit a hidden synthetic
         # abbreviation for fuzz validation before the visible inline-math copy.
+        # Only emit when the converted expression is fuzz-safe (no remaining
+        # DAT constructs like sigma, join, GROUP in predicates/domains).
         if self.use_fuzz and isinstance(expr, SetComprehension):
             hidden_expr = self._replace_binding_with_tuple(expr)
-            synth_name = self._next_synth_name()
-            hidden_lines = self._emit_hidden_abbreviation(synth_name, hidden_expr)
-            return hidden_lines + self._generate_expr_document_item(expr)
+            if not self._expression_contains_dat_construct(hidden_expr):
+                synth_name = self._next_synth_name()
+                hidden_lines = self._emit_hidden_abbreviation(synth_name, hidden_expr)
+                return hidden_lines + self._generate_expr_document_item(expr)
 
         return self._generate_expr_document_item(expr)
 

--- a/src/txt2tex/codegen/expressions.py
+++ b/src/txt2tex/codegen/expressions.py
@@ -947,7 +947,9 @@ class _ExpressionsCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass
         # environment for proper multi-line rendering.  The opening
         # brace sits on the first row and the closing brace on the
         # last row (textbook convention).
-        if node.line_break_after_pipe or node.line_break_after_bullet:
+        if (
+            node.line_break_after_pipe or node.line_break_after_bullet
+        ) and not self._in_hidden_fuzz_block:
             inner = result[len(r"\{~ ") :].removesuffix(r"~\}")
             return (
                 r"\begin{array}{l}"

--- a/src/txt2tex/codegen/fuzz_routing.py
+++ b/src/txt2tex/codegen/fuzz_routing.py
@@ -18,12 +18,16 @@ from typing import ClassVar, cast
 from txt2tex.ast_nodes import (
     Binding,
     Divide,
+    Expr,
     Group,
     GroupAggregate,
+    Identifier,
     NaturalJoin,
     Project,
     RelationRename,
     Restrict,
+    SetComprehension,
+    Tuple,
     Ungroup,
 )
 from txt2tex.codegen._dispatch import CodegenDispatch
@@ -66,3 +70,65 @@ class _FuzzRoutingCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass
             elif self._expression_contains_dat_construct(value):
                 return True
         return False
+
+    def _binding_to_tuple_expr(self, binding: Binding) -> Expr:
+        """Convert a binding to the equivalent tuple expression for fuzz.
+
+        Single-field: bare expression. Multi-field: tuple.
+        """
+        if len(binding.pairs) <= 1:
+            if not binding.pairs:
+                # Empty binding — return an empty-set placeholder
+                return Identifier(
+                    name="\\emptyset", line=binding.line, column=binding.column
+                )
+            return binding.pairs[0][1]
+        return Tuple(
+            elements=[v for _, v in binding.pairs],
+            line=binding.line,
+            column=binding.column,
+        )
+
+    def _replace_binding_with_tuple(self, node: SetComprehension) -> SetComprehension:
+        """Return a fuzz-safe copy of the set comprehension.
+
+        If the characteristic expression is a Binding, replace with
+        the equivalent tuple so fuzz can validate the types.
+        """
+        if not isinstance(node.expression, Binding):
+            return node
+        return SetComprehension(
+            variables=node.variables,
+            domain=node.domain,
+            predicate=node.predicate,
+            expression=self._binding_to_tuple_expr(node.expression),
+            extra_declarations=node.extra_declarations,
+            line_break_after_pipe=node.line_break_after_pipe,
+            line_break_after_bullet=node.line_break_after_bullet,
+            line=node.line,
+            column=node.column,
+        )
+
+    def _emit_hidden_abbreviation(self, name_latex: str, expr: Expr) -> list[str]:
+        r"""Emit a hidden fuzz-validation abbreviation inside \\setbox0=\\vbox{%...}.
+
+        The box is discarded at typeset time but fuzz reads and validates it.
+        Sets ``_in_hidden_fuzz_block`` so nested generators suppress
+        \begin{array} wrapping that fuzz would reject.
+        """
+        prev_z = self._in_z_paragraph
+        prev_hidden = self._in_hidden_fuzz_block
+        self._in_z_paragraph = True
+        self._in_hidden_fuzz_block = True
+        try:
+            expr_latex = self.generate_expr(expr)
+        finally:
+            self._in_z_paragraph = prev_z
+            self._in_hidden_fuzz_block = prev_hidden
+        return [
+            r"\setbox0=\vbox{%",
+            r"\begin{zed}",
+            f"{name_latex} == {expr_latex}",
+            r"\end{zed}%",
+            "}",
+        ]

--- a/src/txt2tex/codegen/paragraphs.py
+++ b/src/txt2tex/codegen/paragraphs.py
@@ -225,7 +225,12 @@ class _ParagraphsCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
                 and isinstance(node.expression.expression, Binding)
             ):
                 converted = self._replace_binding_with_tuple(node.expression)
-                lines.extend(self._emit_hidden_abbreviation(name_latex, converted))
+                if node.generic_params:
+                    params_str = ", ".join(node.generic_params)
+                    hidden_name = f"{name_latex}[{params_str}]"
+                else:
+                    hidden_name = name_latex
+                lines.extend(self._emit_hidden_abbreviation(hidden_name, converted))
             # Relational RHS — emit outside any Z environment so fuzz silently skips
             lines.append("\\noindent")
             lines.append(f"${abbrev}$")

--- a/src/txt2tex/codegen/paragraphs.py
+++ b/src/txt2tex/codegen/paragraphs.py
@@ -225,12 +225,13 @@ class _ParagraphsCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
                 and isinstance(node.expression.expression, Binding)
             ):
                 converted = self._replace_binding_with_tuple(node.expression)
-                if node.generic_params:
-                    params_str = ", ".join(node.generic_params)
-                    hidden_name = f"{name_latex}[{params_str}]"
-                else:
-                    hidden_name = name_latex
-                lines.extend(self._emit_hidden_abbreviation(hidden_name, converted))
+                if not self._expression_contains_dat_construct(converted):
+                    if node.generic_params:
+                        params_str = ", ".join(node.generic_params)
+                        hidden_name = f"{name_latex}[{params_str}]"
+                    else:
+                        hidden_name = name_latex
+                    lines.extend(self._emit_hidden_abbreviation(hidden_name, converted))
             # Relational RHS — emit outside any Z environment so fuzz silently skips
             lines.append("\\noindent")
             lines.append(f"${abbrev}$")

--- a/src/txt2tex/codegen/paragraphs.py
+++ b/src/txt2tex/codegen/paragraphs.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from txt2tex.ast_nodes import (
     Abbreviation,
     AxDef,
+    Binding,
     Document,
     Expr,
     FreeType,
@@ -21,6 +22,7 @@ from txt2tex.ast_nodes import (
     Identifier,
     SchemaInclusion,
     SequenceLiteral,
+    SetComprehension,
     SyntaxBlock,
     SyntaxDefinition,
     Zed,
@@ -215,6 +217,15 @@ class _ParagraphsCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
 
         # Pick the wrapping based on RHS content
         if is_relational_rhs:
+            # Dual-emit for binding set comprehensions: hidden copy with
+            # tuple for fuzz validation, visible copy with binding for PDF.
+            if (
+                self.use_fuzz
+                and isinstance(node.expression, SetComprehension)
+                and isinstance(node.expression.expression, Binding)
+            ):
+                converted = self._replace_binding_with_tuple(node.expression)
+                lines.extend(self._emit_hidden_abbreviation(name_latex, converted))
             # Relational RHS — emit outside any Z environment so fuzz silently skips
             lines.append("\\noindent")
             lines.append(f"${abbrev}$")

--- a/src/txt2tex/latex_gen.py
+++ b/src/txt2tex/latex_gen.py
@@ -283,13 +283,20 @@ class LaTeXGenerator(
         while i < len(items):
             item = items[i]
             # Check if this is a zed-generating item
-            if isinstance(item, (GivenType, FreeType, Abbreviation)):
-                # Collect consecutive zed items
+            if isinstance(item, (GivenType, FreeType, Abbreviation)) and not (
+                isinstance(item, Abbreviation)
+                and self._expression_contains_dat_construct(item.expression)
+            ):
+                # Collect consecutive zed items (exclude DAT abbreviations)
                 zed_items: list[GivenType | FreeType | Abbreviation] = [item]
                 j = i + 1
                 while j < len(items):
                     next_item = items[j]
                     if not isinstance(next_item, (GivenType, FreeType, Abbreviation)):
+                        break
+                    if isinstance(
+                        next_item, Abbreviation
+                    ) and self._expression_contains_dat_construct(next_item.expression):
                         break
                     zed_items.append(next_item)
                     j += 1

--- a/src/txt2tex/latex_gen.py
+++ b/src/txt2tex/latex_gen.py
@@ -165,6 +165,8 @@ class LaTeXGenerator(
     _overflow_threshold: int
     _overflow_warnings: list[str]
     _dollar_sanitise_registry: dict[str, str]
+    _synth_abbrev_counter: int
+    _in_hidden_fuzz_block: bool
 
     def __init__(
         self,
@@ -201,6 +203,13 @@ class LaTeXGenerator(
         self._overflow_warnings = []  # Collected warnings to emit
         # Populated by _pre_sanitise_dollars, consumed by _restore_dollar_sanitise
         self._dollar_sanitise_registry = {}
+        self._synth_abbrev_counter = 0
+        self._in_hidden_fuzz_block = False
+
+    def _next_synth_name(self) -> str:
+        """Generate the next synthetic abbreviation name for fuzz validation."""
+        self._synth_abbrev_counter += 1
+        return f"zS_{self._synth_abbrev_counter}"
 
     # -------------------------------------------------------------------------
     # Overflow warning helpers

--- a/tests/test_14_relational_databases/test_set_comp_fuzz_validation.py
+++ b/tests/test_14_relational_databases/test_set_comp_fuzz_validation.py
@@ -1,0 +1,219 @@
+"""Tests for dual-emit fuzz validation of set comprehensions.
+
+Two orthogonal transforms:
+1. Synthetic abbreviation: standalone set comprehensions get a hidden
+   \\setbox0=\\vbox{\\begin{zed}zS_N == ...\\end{zed}} for fuzz validation.
+2. Binding-to-tuple: binding characteristic expressions become tuples
+   in the hidden fuzz copy.
+
+Four cases:
+A. Standalone set comp, no binding → synthetic abbrev, same expression
+B. Standalone set comp, binding → synthetic abbrev + binding→tuple
+C. Abbreviation with binding → dual-emit: hidden tuple, visible binding
+D. Abbreviation without binding → no change (already fuzz-validated)
+"""
+
+from __future__ import annotations
+
+from txt2tex.ast_nodes import Document
+from txt2tex.latex_gen import LaTeXGenerator
+from txt2tex.lexer import Lexer
+from txt2tex.parser import Parser
+
+_HEADER = "=== Test ===\n\n"
+
+
+def _generate(src: str, *, use_fuzz: bool = True) -> str:
+    """Parse src and generate full LaTeX document.
+
+    Wraps bare expressions in a section header so they parse as
+    Document items (not bare Expr), which is the path that triggers
+    generate_document_item and the dual-emit logic.
+    """
+    if not src.startswith("===") and not src.startswith("given"):
+        src = _HEADER + src
+    ast = Parser(Lexer(src).tokenize()).parse()
+    gen = LaTeXGenerator(use_fuzz=use_fuzz)
+    assert isinstance(ast, Document)
+    return gen.generate_document(ast)
+
+
+# ===================================================================
+# Case A: standalone set comprehension, no binding
+# ===================================================================
+
+
+class TestStandaloneSetCompNoBinding:
+    """Standalone set comprehensions without bindings get a hidden
+    synthetic abbreviation for fuzz validation."""
+
+    def test_hidden_abbreviation_emitted(self) -> None:
+        """{ x : N | x > 0 } → output contains hidden \\setbox0 block."""
+        latex = _generate("{ x : N | x > 0 }")
+        assert r"\setbox0=\vbox{%" in latex
+        assert r"\begin{zed}" in latex
+
+    def test_synthetic_name_in_hidden_copy(self) -> None:
+        """Hidden copy uses a synthetic name like zS_1."""
+        latex = _generate("{ x : N | x > 0 }")
+        assert "zS_" in latex
+
+    def test_visible_copy_is_inline_math(self) -> None:
+        """Visible copy remains as \\noindent$...$."""
+        latex = _generate("{ x : N | x > 0 }")
+        assert r"\noindent" in latex
+        assert "$" in latex
+
+    def test_fuzz_disabled_no_hidden_copy(self) -> None:
+        """With use_fuzz=False, no hidden copy is emitted."""
+        latex = _generate("{ x : N | x > 0 }", use_fuzz=False)
+        assert r"\setbox0" not in latex
+
+    def test_counter_increments(self) -> None:
+        """Two standalone set comps get zS_1 and zS_2."""
+        src = "{ x : N | x > 0 }\n{ y : N | y > 1 }"
+        latex = _generate(src)
+        assert "zS_1" in latex
+        assert "zS_2" in latex
+
+
+# ===================================================================
+# Case B: standalone set comprehension with binding
+# ===================================================================
+
+
+class TestStandaloneSetCompWithBinding:
+    """Standalone set comprehensions with binding characteristic
+    expressions get a hidden copy with the binding converted to a
+    tuple."""
+
+    def test_hidden_copy_has_no_binding(self) -> None:
+        """Hidden copy converts binding to tuple — no \\lblot."""
+        src = "{ m : Members | m.username = m.username . {| name == m.username |} }"
+        latex = _generate(src)
+        # Find the \setbox0 block
+        setbox_start = latex.find(r"\setbox0")
+        assert setbox_start >= 0
+        vbox_close = latex.find("\n}\n", setbox_start)
+        hidden_block = latex[setbox_start:vbox_close]
+        assert r"\lblot" not in hidden_block
+
+    def test_visible_copy_has_binding(self) -> None:
+        """Visible copy preserves the binding."""
+        src = "{ m : Members | m.username = m.username . {| name == m.username |} }"
+        latex = _generate(src)
+        # The visible part (after the hidden block) should have \lblot
+        setbox_start = latex.find(r"\setbox0")
+        assert setbox_start >= 0
+        vbox_close = latex.find("\n}\n", setbox_start)
+        visible_part = latex[vbox_close:]
+        assert r"\lblot" in visible_part
+
+    def test_multi_field_binding_becomes_tuple(self) -> None:
+        """Multi-field binding converts to tuple in hidden copy."""
+        src = (
+            "{ s : Ship; c : Class | s.class = c.class . "
+            "{| name == s.name, disp == c.displacement |} }"
+        )
+        latex = _generate(src)
+        setbox_start = latex.find(r"\setbox0")
+        assert setbox_start >= 0
+        vbox_close = latex.find("\n}\n", setbox_start)
+        hidden_block = latex[setbox_start:vbox_close]
+        assert r"\lblot" not in hidden_block
+        # Hidden block should have the tuple components without binding syntax
+        assert "s.name" in hidden_block or "name" in hidden_block
+
+
+# ===================================================================
+# Case C: abbreviation with binding characteristic expression
+# ===================================================================
+
+
+class TestAbbreviationWithBinding:
+    """Abbreviations whose RHS is a set comprehension with a binding
+    characteristic expression dual-emit: hidden copy with tuple,
+    visible copy with binding."""
+
+    def test_dual_emit_structure(self) -> None:
+        """S == { m : Members | pred . {| ... |} } emits both hidden
+        and visible copies."""
+        src = (
+            "given UserType\n"
+            "schema Members\n  username : UserType\nend\n\n"
+            "S == { m : Members | m.username = m.username . "
+            "{| name == m.username |} }"
+        )
+        latex = _generate(src)
+        assert r"\setbox0=\vbox{%" in latex
+        assert r"\noindent" in latex
+
+    def test_hidden_copy_has_tuple_not_binding(self) -> None:
+        """Hidden copy converts binding to tuple."""
+        src = (
+            "given UserType\n"
+            "schema Members\n  username : UserType\nend\n\n"
+            "S == { m : Members | m.username = m.username . "
+            "{| name == m.username |} }"
+        )
+        latex = _generate(src)
+        setbox_start = latex.find(r"\setbox0")
+        assert setbox_start >= 0
+        vbox_close = latex.find("\n}\n", setbox_start)
+        hidden_block = latex[setbox_start:vbox_close]
+        assert r"\lblot" not in hidden_block
+        assert "S ==" in hidden_block
+
+    def test_visible_copy_has_binding(self) -> None:
+        """Visible copy preserves the binding syntax."""
+        src = (
+            "given UserType\n"
+            "schema Members\n  username : UserType\nend\n\n"
+            "S == { m : Members | m.username = m.username . "
+            "{| name == m.username |} }"
+        )
+        latex = _generate(src)
+        setbox_start = latex.find(r"\setbox0")
+        vbox_close = latex.find("\n}\n", setbox_start)
+        visible_part = latex[vbox_close:]
+        assert r"\lblot" in visible_part
+        assert "S ==" in visible_part
+
+    def test_abbreviation_name_in_both_copies(self) -> None:
+        """The abbreviation name appears in both hidden and visible."""
+        src = (
+            "given UserType\n"
+            "schema Members\n  username : UserType\nend\n\n"
+            "S == { m : Members | m.username = m.username . "
+            "{| name == m.username |} }"
+        )
+        latex = _generate(src)
+        setbox_start = latex.find(r"\setbox0")
+        vbox_close = latex.find("\n}\n", setbox_start)
+        hidden_block = latex[setbox_start:vbox_close]
+        visible_part = latex[vbox_close:]
+        assert "S ==" in hidden_block
+        assert "S ==" in visible_part
+
+
+# ===================================================================
+# Case D: abbreviation without binding — no change
+# ===================================================================
+
+
+class TestAbbreviationWithoutBinding:
+    """Abbreviations without binding characteristic expressions are
+    unchanged — no dual-emit needed."""
+
+    def test_pure_z_abbreviation_no_setbox(self) -> None:
+        """Pairs == N cross N → single \\begin{zed}, no \\setbox0."""
+        latex = _generate("Pairs == N cross N")
+        assert r"\setbox0" not in latex
+        assert r"\begin{zed}" in latex
+
+    def test_algebra_abbreviation_no_setbox(self) -> None:
+        """R == sigma[p](S) → \\noindent$...$, no \\setbox0."""
+        src = "given T\nschema S\n  x : T\nend\n\nR == sigma[x = x](S)"
+        latex = _generate(src)
+        assert r"\setbox0" not in latex
+        assert r"\noindent" in latex


### PR DESCRIPTION
## Summary

- Set comprehensions with binding characteristic expressions are now fuzz-validated via a hidden copy that converts bindings to tuples
- Standalone set comprehensions get synthetic abbreviations (`zS_1`, `zS_2`, ...) for fuzz validation
- `_in_hidden_fuzz_block` flag suppresses `\begin{array}` wrapping inside hidden copies
- ADR added to DESIGN.md; CHANGELOG updated under [Unreleased]

## Test plan

- [ ] `make check` passes (4761 passed, 3 xfail)
- [ ] Manual: `fuzz -t` on solutions file shows `zS_N` abbreviations with correct types
- [ ] Manual: PDF renders correctly (hidden copies invisible, bindings display as expected)
- [ ] No regressions in existing set comprehension, binding, or schema tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes LaTeX emission and zed consolidation for set comprehensions in fuzz mode; incorrect guards could add hidden zed blocks or skip validation, but scope is limited to codegen with new tests and no parser changes.
> 
> **Overview**
> When **fuzz** is enabled, set comprehensions that used to render only as inline math (and were skipped by fuzz) now get a **dual-emit** path: a discarded `\setbox0=\vbox{...\begin{zed}...\end{zed}}` copy for type-checking plus the unchanged visible PDF math.
> 
> **Standalone** set comprehensions gain synthetic abbreviations (`zS_1`, `zS_2`, …). **Abbreviation RHS** set comprehensions whose characteristic expression is a `{| ... |}` binding emit a hidden copy with bindings rewritten to tuples (single field → expression, multiple → tuple), while the visible output still shows bindings.
> 
> Hidden copies skip `\begin{array}` wrapping via `_in_hidden_fuzz_block`, and dual-emit is skipped when the fuzz-safe form still contains DAT constructs (e.g. `sigma`, `join`). Zed consolidation also stops grouping abbreviations whose RHS contains DAT constructs. Documentation and **14 tests** cover the four standalone/abbrev × binding cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e86e1b9173a25cf6532c9addcd5812f407333a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->