### PR TITLE
chore(release): v1.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.3] - 2026-05-29
+
 ### Added
 
 - **Dual-emit fuzz validation for set comprehensions** — set

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,7 +222,7 @@ Every code change follows this pipeline. Steps are ordered.
 3. **Enter the review loop.**  This is iterative — typically 2–6
    rounds.  Use `/loop 2m` to poll; never block the session.
 
-   ```
+   ```text
    Push → wait for bot reviews → address findings → push → repeat
    ```
 

--- a/examples/03_equality/bullet_separator.tex
+++ b/examples/03_equality/bullet_separator.tex
@@ -20,6 +20,11 @@
 
 \bigskip
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_1 == \{~ x : \nat | x > 0 @ x * x ~\}
+\end{zed}%
+}
 \noindent
 $\{~ x : \nat | x > 0 @ x * x ~\}$
 
@@ -35,6 +40,11 @@ $\{~ x : \nat | x > 0 @ x * x ~\}$
 
 \bigskip
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_2 == \{~ x : \nat | x > 0 \land x < 10 ~\}
+\end{zed}%
+}
 \noindent
 $\{~ x : \nat | x > 0 \land x < 10 ~\}$
 
@@ -50,6 +60,11 @@ $\{~ x : \nat | x > 0 \land x < 10 ~\}$
 
 \bigskip
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_3 == \{~ n : \nat | n < 5 @ n * n ~\}
+\end{zed}%
+}
 \noindent
 $\{~ n : \nat | n < 5 @ n * n ~\}$
 
@@ -62,6 +77,11 @@ $\{~ n : \nat | n < 5 @ n * n ~\}$
 
 \bigskip
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_4 == \{~ n : \nat | n < 5 ~\}
+\end{zed}%
+}
 \noindent
 $\{~ n : \nat | n < 5 ~\}$
 
@@ -110,6 +130,11 @@ $(\mu n : \nat | n * n = 16 @ n + 1)$
 \section*{Example 7 : Nested Expressions}
 \addcontentsline{toc}{section}{Example 7 : Nested Expressions}
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_5 == \{~ x : \nat | x < 3 @ \{~ y : \nat | y < x @ (x, y) ~\} ~\}
+\end{zed}%
+}
 \noindent
 $\{~ x : \nat | x < 3 @ \{~ y : \nat | y < x @ (x, y) ~\} ~\}$
 
@@ -185,6 +210,11 @@ high\_salaries = \{~ e : Employee | salaries(e) > 100000 @ salaries(e) ~\}
 
 \bigskip
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_6 == \{~ n : \nat | n < 10 @ n * n ~\}
+\end{zed}%
+}
 \noindent
 $\{~ n : \nat | n < 10 @ n * n ~\}$
 
@@ -197,6 +227,11 @@ $\{~ n : \nat | n < 10 @ n * n ~\}$
 
 \bigskip
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_7 == \{~ n : \nat | n \mod 2 = 0 ~\}
+\end{zed}%
+}
 \noindent
 $\{~ n : \nat | n \mod 2 = 0 ~\}$
 

--- a/examples/03_equality/equality_operators.tex
+++ b/examples/03_equality/equality_operators.tex
@@ -50,10 +50,20 @@ $\exists y : \num @ y = 0$
 
 \bigskip
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_1 == \{~ z : \num | z = 10 ~\}
+\end{zed}%
+}
 \noindent
 $\{~ z : \num | z = 10 ~\}$
 
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_2 == \{~ n : \nat | n = n ~\}
+\end{zed}%
+}
 \noindent
 $\{~ n : \nat | n = n ~\}$
 

--- a/examples/05_sets/cartesian_tuples.tex
+++ b/examples/05_sets/cartesian_tuples.tex
@@ -22,6 +22,11 @@
 
 \bigskip
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_1 == \{~ x : \nat | x > 0 ~\}
+\end{zed}%
+}
 \noindent
 $\{~ x : \nat | x > 0 ~\}$
 
@@ -34,6 +39,11 @@ $\{~ x : \nat | x > 0 ~\}$
 
 \bigskip
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_2 == \{~ x, y : \nat | x = y ~\}
+\end{zed}%
+}
 \noindent
 $\{~ x, y : \nat | x = y ~\}$
 
@@ -46,6 +56,11 @@ $\{~ x, y : \nat | x = y ~\}$
 
 \bigskip
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_3 == \{~ x | x \in A ~\}
+\end{zed}%
+}
 \noindent
 $\{~ x | x \in A ~\}$
 
@@ -59,6 +74,11 @@ $\{~ x | x \in A ~\}$
 
 \bigskip
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_4 == \{~ x : \nat | x > 0 @ x \bsup 2 \esup ~\}
+\end{zed}%
+}
 \noindent
 $\{~ x : \nat | x > 0 @ x \bsup 2 \esup ~\}$
 
@@ -96,6 +116,11 @@ $\{~ x : \nat | x > 0 ~\} = \{~ y : \nat | y > 0 ~\}$
 
 \bigskip
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_5 == \{~ x : \nat | x > 0 \land x \leq 10 ~\}
+\end{zed}%
+}
 \noindent
 $\{~ x : \nat | x > 0 \land x \leq 10 ~\}$
 

--- a/examples/05_sets/tuple_examples.tex
+++ b/examples/05_sets/tuple_examples.tex
@@ -54,6 +54,11 @@ $Set(comprehension)$
 $with(tuple)(expression)$
 
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_1 == \{~ n : \nat | n \leq 4 @ (n, n \bsup 2 \esup) ~\}
+\end{zed}%
+}
 \noindent
 $\{~ n : \nat | n \leq 4 @ (n, n \bsup 2 \esup) ~\}$
 

--- a/examples/07_relations/range_examples.tex
+++ b/examples/07_relations/range_examples.tex
@@ -30,6 +30,11 @@ $1993 \upto current$
 \section*{Test 3 : Range elem Set Comprehension}
 \addcontentsline{toc}{section}{Test 3 : Range elem Set Comprehension}
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_1 == \{~ x : 1 \upto 20 | x \mod 2 = 0 ~\}
+\end{zed}%
+}
 \noindent
 $\{~ x : 1 \upto 20 | x \mod 2 = 0 ~\}$
 
@@ -67,6 +72,11 @@ $p.1 \upto p.2$
 \section*{Test 8 : Complex Set Comprehension}
 \addcontentsline{toc}{section}{Test 8 : Complex Set Comprehension}
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_2 == \{~ x : 1 \upto 10 | x > 3 @ x \bsup 2 \esup ~\}
+\end{zed}%
+}
 \noindent
 $\{~ x : 1 \upto 10 | x > 3 @ x \bsup 2 \esup ~\}$
 

--- a/examples/07_relations/relational_composition.tex
+++ b/examples/07_relations/relational_composition.tex
@@ -136,6 +136,11 @@ $\emptyset[\nat] \cup \{x\}$
 
 \subsection*{(a)}
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_1 == \{~ s : \power \nat | s = \emptyset[\nat] ~\}
+\end{zed}%
+}
 \noindent
 $\{~ s : \power \nat | s = \emptyset[\nat] ~\}$
 
@@ -144,6 +149,11 @@ $\{~ s : \power \nat | s = \emptyset[\nat] ~\}$
 
 \subsection*{(b)}
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_2 == \{~ x : \seq \nat | \# x > 0 ~\}
+\end{zed}%
+}
 \noindent
 $\{~ x : \seq \nat | \# x > 0 ~\}$
 

--- a/examples/07_relations/relational_image.tex
+++ b/examples/07_relations/relational_image.tex
@@ -56,6 +56,11 @@ $(R \inv \limg S \rimg)$
 \section*{Example 6 : Set comprehension with relational image ( Solution 35 pattern )}
 \addcontentsline{toc}{section}{Example 6 : Set comprehension with relational image ( Solution 35 pattern )}
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_1 == \{~ p : Person | p \in \dom parentOf @ (p, (parentOf \limg \{p\} \rimg)) ~\}
+\end{zed}%
+}
 \noindent
 $\{~ p : Person | p \in \dom parentOf @ (p, (parentOf \limg \{p\} \rimg)) ~\}$
 

--- a/examples/08_functions/sequences_bags_tuples.tex
+++ b/examples/08_functions/sequences_bags_tuples.tex
@@ -244,6 +244,11 @@ $\exists s : \seq \nat @ head(s) = 1$
 
 \subsection*{(c)}
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_1 == \{~ x : \nat | x > 0 @ \langle x, x \bsup 2 \esup \rangle ~\}
+\end{zed}%
+}
 \noindent
 $\{~ x : \nat | x > 0 @ \langle x, x \bsup 2 \esup \rangle ~\}$
 

--- a/examples/10_schemas/scoping_demo.tex
+++ b/examples/10_schemas/scoping_demo.tex
@@ -57,6 +57,11 @@ $\forall x : \nat @ x > 0 \implies (\exists x : \nat @ x < 10)$
 \section*{Example 4 : Set Comprehension Scope}
 \addcontentsline{toc}{section}{Example 4 : Set Comprehension Scope}
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_1 == \{~ x : \nat | x > 0 \land x < 10 ~\}
+\end{zed}%
+}
 \noindent
 $\{~ x : \nat | x > 0 \land x < 10 ~\}$
 
@@ -68,6 +73,11 @@ $\{~ x : \nat | x > 0 \land x < 10 ~\}$
 \section*{Example 5 : Bullet Separator Scope}
 \addcontentsline{toc}{section}{Example 5 : Bullet Separator Scope}
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_2 == \{~ x : \nat | x < 5 @ x * x ~\}
+\end{zed}%
+}
 \noindent
 $\{~ x : \nat | x < 5 @ x * x ~\}$
 
@@ -239,6 +249,11 @@ $(\mu x : \nat | x * x = 25)$
 \section*{Example 16 : Set Comprehension with Multiple Variables}
 \addcontentsline{toc}{section}{Example 16 : Set Comprehension with Multiple Variables}
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_3 == \{~ x, y : \nat | x < y \land y < 10 @ (x, y) ~\}
+\end{zed}%
+}
 \noindent
 $\{~ x, y : \nat | x < y \land y < 10 @ (x, y) ~\}$
 

--- a/examples/11_text_blocks/bibliography_example.tex
+++ b/examples/11_text_blocks/bibliography_example.tex
@@ -12,7 +12,7 @@
 \title{Bibliography Example}
 \author{Example Author}
 \date{2025}
-\hypersetup{pdftitle={Bibliography Example},pdfauthor={Example Author},pdfcreator={txt2tex v1.6.2}}
+\hypersetup{pdftitle={Bibliography Example},pdfauthor={Example Author},pdfcreator={txt2tex v1.6.3}}
 \begin{document}
 
 \maketitle

--- a/examples/12_advanced/if_then_else.tex
+++ b/examples/12_advanced/if_then_else.tex
@@ -71,6 +71,11 @@ sign : \num \fun \{-1, 0, 1\}
 \section*{Example 5 : Conditional elem Set Comprehension}
 \addcontentsline{toc}{section}{Example 5 : Conditional elem Set Comprehension}
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_1 == \{~ x : \nat | x < 10 @ \IF x \mod 2 = 0 \THEN x \ELSE x + 1 ~\}
+\end{zed}%
+}
 \noindent
 $\{~ x : \nat | x < 10 @ \IF x \mod 2 = 0 \THEN x \ELSE x + 1 ~\}$
 

--- a/examples/12_advanced/subscripts_superscripts.tex
+++ b/examples/12_advanced/subscripts_superscripts.tex
@@ -86,6 +86,11 @@ $\forall i : 1 \upto n @ s\_i \in \nat$
 \section*{Example 5 : Exponentiation in Expressions}
 \addcontentsline{toc}{section}{Example 5 : Exponentiation in Expressions}
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_1 == \{~ n : \nat | n < 10 @ n \bsup 2 \esup ~\}
+\end{zed}%
+}
 \noindent
 $\{~ n : \nat | n < 10 @ n \bsup 2 \esup ~\}$
 

--- a/examples/14_relational_databases/algebra_basics.tex
+++ b/examples/14_relational_databases/algebra_basics.tex
@@ -11,7 +11,7 @@
 \newdimen\savedleftskip
 \title{Relational Algebra}
 \author{txt2tex example}
-\hypersetup{pdftitle={Relational Algebra},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.2}}
+\hypersetup{pdftitle={Relational Algebra},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.3}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/bindings.tex
+++ b/examples/14_relational_databases/bindings.tex
@@ -11,7 +11,7 @@
 \newdimen\savedleftskip
 \title{Z Binding Calculus}
 \author{txt2tex example}
-\hypersetup{pdftitle={Z Binding Calculus},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.2}}
+\hypersetup{pdftitle={Z Binding Calculus},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.3}}
 \begin{document}
 
 \maketitle
@@ -39,6 +39,11 @@ $\lblot~trackId == t.trackId~\rblot$
 
 \section*{Binding in Set Comprehension}
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_1 == \{~ t : Track | t.duration < 180 @ t.trackId ~\}
+\end{zed}%
+}
 \noindent
 $\{~ t : Track | t.duration < 180 @ \lblot~trackId == t.trackId~\rblot ~\}$
 
@@ -51,6 +56,11 @@ $\lblot~trackId == t.trackId, year == a.year, tracks == a.tracks~\rblot$
 
 \section*{Multi-Variable Comprehension with Binding}
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_2 == \{~ t : Track ; a : Album | t.albumId = a.albumId @ \\ (t.trackId, a.year, a.tracks) ~\}
+\end{zed}%
+}
 \noindent
 $\begin{array}{l}\{~ t : Track ; a : Album | t.albumId = a.albumId @ \\ \lblot~trackId == t.trackId, year == a.year, tracks == a.tracks~\rblot  ~\}\end{array}$
 

--- a/examples/14_relational_databases/foreign_keys.tex
+++ b/examples/14_relational_databases/foreign_keys.tex
@@ -11,7 +11,7 @@
 \newdimen\savedleftskip
 \title{Foreign Keys in Relational Schemas}
 \author{txt2tex example}
-\hypersetup{pdftitle={Foreign Keys in Relational Schemas},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.2}}
+\hypersetup{pdftitle={Foreign Keys in Relational Schemas},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.3}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/group_ungroup.tex
+++ b/examples/14_relational_databases/group_ungroup.tex
@@ -11,7 +11,7 @@
 \newdimen\savedleftskip
 \title{GROUP and UNGROUP}
 \author{txt2tex example}
-\hypersetup{pdftitle={GROUP and UNGROUP},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.2}}
+\hypersetup{pdftitle={GROUP and UNGROUP},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.3}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/normalisation.tex
+++ b/examples/14_relational_databases/normalisation.tex
@@ -11,7 +11,7 @@
 \newdimen\savedleftskip
 \title{Functional Dependencies and Normalisation}
 \author{txt2tex example}
-\hypersetup{pdftitle={Functional Dependencies and Normalisation},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.2}}
+\hypersetup{pdftitle={Functional Dependencies and Normalisation},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.3}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/primary_keys.tex
+++ b/examples/14_relational_databases/primary_keys.tex
@@ -11,7 +11,7 @@
 \newdimen\savedleftskip
 \title{Primary Keys in Relational Schemas}
 \author{txt2tex example}
-\hypersetup{pdftitle={Primary Keys in Relational Schemas},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.2}}
+\hypersetup{pdftitle={Primary Keys in Relational Schemas},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.3}}
 \begin{document}
 
 \maketitle

--- a/examples/14_relational_databases/relational_calculus.tex
+++ b/examples/14_relational_databases/relational_calculus.tex
@@ -11,7 +11,7 @@
 \newdimen\savedleftskip
 \title{Relational Calculus --- Music Library}
 \author{txt2tex example}
-\hypersetup{pdftitle={Relational Calculus --- Music Library},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.2}}
+\hypersetup{pdftitle={Relational Calculus --- Music Library},pdfauthor={txt2tex example},pdfcreator={txt2tex v1.6.3}}
 \begin{document}
 
 \maketitle
@@ -47,6 +47,11 @@ member : PlaylistId \rel TrackId
 
 \bigskip
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_1 == \{~ t : Track | t.genre = `Jazz' @ \\ (t.title, t.genre) ~\}
+\end{zed}%
+}
 \noindent
 $\begin{array}{l}\{~ t : Track | t.genre = `Jazz' @ \\ \lblot~title == t.title, genre == t.genre~\rblot  ~\}\end{array}$
 
@@ -57,6 +62,12 @@ $\begin{array}{l}\{~ t : Track | t.genre = `Jazz' @ \\ \lblot~title == t.title, 
 
 \bigskip
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_2 == \{~ t : Track ; al : Album ; ar : Artist | t.alid = al.alid \land \\
+\quad al.arid = ar.arid @ \\ (t.title, ar.name) ~\}
+\end{zed}%
+}
 \noindent
 $\displaystyle
 \begin{array}{l}
@@ -72,6 +83,12 @@ $\displaystyle
 
 \bigskip
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_3 == \{~ p : PlaylistId ; t : Track ; al : Album | (p, t.tid) \in member \land \\
+\quad t.alid = al.alid @ \\ (p, t.title, al.title) ~\}
+\end{zed}%
+}
 \noindent
 $\displaystyle
 \begin{array}{l}
@@ -87,6 +104,12 @@ $\displaystyle
 
 \bigskip
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_4 == \{~ t : Track ; al : Album | t.alid = al.alid \land \\
+\quad t.duration > 300 @ \\ (t.title, al.title) ~\}
+\end{zed}%
+}
 \noindent
 $\displaystyle
 \begin{array}{l}
@@ -113,6 +136,12 @@ $\displaystyle
 
 \bigskip
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_5 == \{~ t : Track ; al : Album | t.alid = al.alid \land \\
+\quad t.duration > 300 ~\}
+\end{zed}%
+}
 \noindent
 $\displaystyle
 \begin{array}{l}

--- a/examples/16_multi_decl_calculus/q2d_demo.tex
+++ b/examples/16_multi_decl_calculus/q2d_demo.tex
@@ -11,7 +11,7 @@
 \newdimen\savedleftskip
 \title{Multi-Declaration Z Constructs --- Demo}
 \author{txt2tex}
-\hypersetup{pdftitle={Multi-Declaration Z Constructs --- Demo},pdfauthor={txt2tex},pdfcreator={txt2tex v1.6.2}}
+\hypersetup{pdftitle={Multi-Declaration Z Constructs --- Demo},pdfauthor={txt2tex},pdfcreator={txt2tex v1.6.3}}
 \begin{document}
 
 \maketitle
@@ -90,6 +90,13 @@ $\displaystyle
 
 \bigskip
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_1 == \{~ m : Match ; t : Tournament ; p : Player | m.tournament = t.tournamentId \land \\
+\quad m.winner = p.name \land \\
+\quad t.venue = `Centre Court' @ \\ (m.winner, t.venue, t.tier) ~\}
+\end{zed}%
+}
 \noindent
 $\displaystyle
 \begin{array}{l}
@@ -116,6 +123,11 @@ $\displaystyle
 
 \bigskip
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_2 == \{~ m : Match ; t : Tournament | m.tournament = t.tournamentId \land t.tier \leq 2 ~\}
+\end{zed}%
+}
 \noindent
 $\{~ m : Match ; t : Tournament | m.tournament = t.tournamentId \land t.tier \leq 2 ~\}$
 

--- a/examples/fuzz_tests/test_nested_super.tex
+++ b/examples/fuzz_tests/test_nested_super.tex
@@ -13,6 +13,11 @@
 
 \section*{Test Nested Superscript}
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_1 == \{~ z : \num | z \mod 2 = 0 @ {z \bsup 2 \esup} \bsup 3 \esup ~\}
+\end{zed}%
+}
 \noindent
 $\{~ z : \num | z \mod 2 = 0 @ {z \bsup 2 \esup} \bsup 3 \esup ~\}$
 

--- a/examples/user_guide/18_set_comprehension.tex
+++ b/examples/user_guide/18_set_comprehension.tex
@@ -11,18 +11,38 @@
 \newdimen\savedleftskip
 \begin{document}
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_1 == \{~ x : \nat | x > 0 ~\}
+\end{zed}%
+}
 \noindent
 $\{~ x : \nat | x > 0 ~\}$
 
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_2 == \{~ x : \nat | x > 0 @ x \bsup 2 \esup ~\}
+\end{zed}%
+}
 \noindent
 $\{~ x : \nat | x > 0 @ x \bsup 2 \esup ~\}$
 
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_3 == \{~ x, y : \nat | x = y ~\}
+\end{zed}%
+}
 \noindent
 $\{~ x, y : \nat | x = y ~\}$
 
 
+\setbox0=\vbox{%
+\begin{zed}
+zS_4 == \{~ x | x \in A ~\}
+\end{zed}%
+}
 \noindent
 $\{~ x | x \in A ~\}$
 

--- a/src/txt2tex/__version__.py
+++ b/src/txt2tex/__version__.py
@@ -1,3 +1,3 @@
 """Defines the version of the txt2tex package."""
 
-__version__ = "1.6.2"
+__version__ = "1.6.3"


### PR DESCRIPTION
## Summary

- Bump version to 1.6.3
- Update CHANGELOG with dual-emit fuzz validation feature
- Regenerate 16 fixture .tex files (hidden `\setbox0` blocks for set comprehensions)
- Fix CLAUDE.md markdown lint (fenced code block language)

## Test plan

- [ ] `make check` passes (4761 passed)
- [ ] `make test-e2e` passes (159 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly version metadata and committed LaTeX fixture output from an already-documented fuzz-validation emit path; no application logic changes appear in this diff.
> 
> **Overview**
> Release **v1.6.3** documents and ships **dual-emit fuzz validation for set comprehensions**: binding characteristic expressions and inline comprehensions are now checked via hidden `\setbox0=\vbox{…}` `zed` abbreviations (`zS_1`, `zS_2`, …) while the visible math stays unchanged.
> 
> **Regenerated example/user-guide `.tex` fixtures** (16+ files) add those hidden blocks ahead of displayed set comprehensions; several PDF metadata lines now say `txt2tex v1.6.3`. **`CHANGELOG.md`** gains the `[1.6.3]` entry; **`src/txt2tex/__version__.py`** is bumped. **`CLAUDE.md`** only fixes a fenced-code language tag for the PR review-loop snippet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c060218124fc23c54ab26e35cf1aa696aa4dd01c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->