### PR TITLE
fix(toc): reset depth per document and find nested CONTENTS

### DIFF
--- a/docs/guides/USER_GUIDE.md
+++ b/docs/guides/USER_GUIDE.md
@@ -73,7 +73,7 @@ Generates: `\subsection*{Solution 1}`
 (c) Third part
 ```
 
-Each part gets proper spacing and formatting with `(a)\par\vspace{11pt}`.
+In the default `PARTS: subsection` mode each part renders as a `\subsubsection*{(a)}` heading; under `PARTS: inline` it renders inline as `(a) ...` with the part text following on the same line.
 
 **Note:** In previous versions, `(a)` rendered `\subsection*`. It now renders `\subsubsection*`, one level smaller.
 

--- a/src/txt2tex/latex_gen.py
+++ b/src/txt2tex/latex_gen.py
@@ -25,14 +25,17 @@ from txt2tex.ast_nodes import (
     Identifier,
     Lambda,
     NaturalJoin,
+    Part,
     Project,
     Quantifier,
     RelationalImage,
     RelationRename,
     Restrict,
+    Section,
     SequenceLiteral,
     SetComprehension,
     SetLiteral,
+    Solution,
     Subscript,
     Superscript,
     Tuple,
@@ -216,6 +219,24 @@ class LaTeXGenerator(
         """Generate the next synthetic abbreviation name for fuzz validation."""
         self._synth_abbrev_counter += 1
         return f"zS_{self._synth_abbrev_counter}"
+
+    def _find_contents_depth(self, items: list[DocumentItem]) -> int | None:
+        """Return the toc depth from the first Contents node found in document order.
+
+        Performs a pre-order DFS through items, descending into the .items of
+        Section, Solution, and Part nodes so that a CONTENTS: directive nested
+        inside a section heading is not silently ignored.
+
+        Returns None when no Contents node exists anywhere in the subtree.
+        """
+        for item in items:
+            if isinstance(item, Contents):
+                return toc_depth_from_keyword(item.depth)
+            if isinstance(item, (Section, Solution, Part)):
+                result = self._find_contents_depth(item.items)
+                if result is not None:
+                    return result
+        return None
 
     # -------------------------------------------------------------------------
     # Overflow warning helpers
@@ -481,11 +502,14 @@ class LaTeXGenerator(
         if isinstance(ast, Document):
             # Store document-level parts format
             self.parts_format = ast.parts_format
-            # Pre-scan for the first Contents node to set TOC depth before generation
-            for _item in ast.items:
-                if isinstance(_item, Contents):
-                    self._toc_depth = toc_depth_from_keyword(_item.depth)
-                    break
+            # Reset per-document TOC depth so a reused generator starts clean.
+            self._toc_depth = 3
+            # Pre-scan: DFS search for the first Contents node anywhere in the
+            # tree.  Top-level-only iteration misses Contents inside Section /
+            # Solution / Part, so we recurse into their .items lists.
+            found_depth = self._find_contents_depth(ast.items)
+            if found_depth is not None:
+                self._toc_depth = found_depth
             # toc_parts overrides depth to 3: all three heading levels enter the TOC
             if self.toc_parts:
                 self._toc_depth = 3

--- a/src/txt2tex/latex_gen.py
+++ b/src/txt2tex/latex_gen.py
@@ -238,6 +238,22 @@ class LaTeXGenerator(
                     return result
         return None
 
+    def _resolve_toc_depth(self, items: list[DocumentItem]) -> None:
+        """Set self._toc_depth for one document body.
+
+        Reset to the default, derive from the first Contents node anywhere in
+        the tree, then apply the --toc-parts override.  Called by both
+        generate_document and generate_fragment so the two entry points cannot
+        diverge: generate_fragment previously skipped this, ignoring CONTENTS:
+        depth in REPL previews and leaking _toc_depth across inputs.
+        """
+        self._toc_depth = 3
+        found_depth = self._find_contents_depth(items)
+        if found_depth is not None:
+            self._toc_depth = found_depth
+        if self.toc_parts:
+            self._toc_depth = 3
+
     # -------------------------------------------------------------------------
     # Overflow warning helpers
     # -------------------------------------------------------------------------
@@ -408,6 +424,7 @@ class LaTeXGenerator(
         """
         # Store document-level parts format
         self.parts_format = ast.parts_format
+        self._resolve_toc_depth(ast.items)
 
         # Generate all document items
         lines = self._generate_document_items_with_consolidation(ast.items)
@@ -502,17 +519,7 @@ class LaTeXGenerator(
         if isinstance(ast, Document):
             # Store document-level parts format
             self.parts_format = ast.parts_format
-            # Reset per-document TOC depth so a reused generator starts clean.
-            self._toc_depth = 3
-            # Pre-scan: DFS search for the first Contents node anywhere in the
-            # tree.  Top-level-only iteration misses Contents inside Section /
-            # Solution / Part, so we recurse into their .items lists.
-            found_depth = self._find_contents_depth(ast.items)
-            if found_depth is not None:
-                self._toc_depth = found_depth
-            # toc_parts overrides depth to 3: all three heading levels enter the TOC
-            if self.toc_parts:
-                self._toc_depth = 3
+            self._resolve_toc_depth(ast.items)
             # Multi-line document: generate each item
             # Consolidate consecutive zed environments
             lines.extend(self._generate_document_items_with_consolidation(ast.items))

--- a/tests/test_11_text_blocks/test_toc_three_levels.py
+++ b/tests/test_11_text_blocks/test_toc_three_levels.py
@@ -7,6 +7,7 @@ CONTENTS: keyword and toc_depth_from_keyword.
 
 from __future__ import annotations
 
+from txt2tex.ast_nodes import Contents, Document, Section
 from txt2tex.codegen._toc import toc_depth_from_keyword
 from txt2tex.latex_gen import LaTeXGenerator
 from txt2tex.lexer import Lexer
@@ -246,3 +247,90 @@ class TestTocPartsOverride:
         assert r"\addcontentsline{toc}{section}{Title}" in latex
         assert r"\addcontentsline{toc}{subsection}{Q1}" not in latex
         assert r"\addcontentsline{toc}{subsubsection}{(a)}" not in latex
+
+
+# ---------------------------------------------------------------------------
+# Reuse isolation (defect 1)
+# ---------------------------------------------------------------------------
+
+
+class TestReuseIsolation:
+    """A reused LaTeXGenerator must not leak _toc_depth across calls.
+
+    The first document sets depth 1 via CONTENTS: 1.  The second document
+    has no CONTENTS: directive, so it must revert to the default depth of 3
+    — meaning all three addcontentsline levels are emitted.
+    """
+
+    _DOC1 = "CONTENTS: 1\n\n=== Title ===\n\n** Q1 **\n\n(a) content\n"
+    _DOC2 = "=== Title ===\n\n** Q1 **\n\n(a) content\n"
+
+    def _parse_ast(self, src: str) -> object:
+        lexer = Lexer(src)
+        tokens = lexer.tokenize()
+        return Parser(tokens).parse()
+
+    def test_second_call_subsubsection_present(self) -> None:
+        # If depth leaks, this is absent because depth 1 was set by doc1.
+        gen = LaTeXGenerator()
+        gen.generate_document(self._parse_ast(self._DOC1))  # type: ignore[arg-type]
+        latex2 = gen.generate_document(self._parse_ast(self._DOC2))  # type: ignore[arg-type]
+        assert r"\addcontentsline{toc}{subsubsection}{(a)}" in latex2
+
+    def test_second_call_subsection_present(self) -> None:
+        gen = LaTeXGenerator()
+        gen.generate_document(self._parse_ast(self._DOC1))  # type: ignore[arg-type]
+        latex2 = gen.generate_document(self._parse_ast(self._DOC2))  # type: ignore[arg-type]
+        assert r"\addcontentsline{toc}{subsection}{Q1}" in latex2
+
+    def test_second_call_matches_fresh_generator(self) -> None:
+        # The reused generator's second output must equal a fresh generator's output.
+        gen_reused = LaTeXGenerator()
+        gen_reused.generate_document(self._parse_ast(self._DOC1))  # type: ignore[arg-type]
+        latex_reused = gen_reused.generate_document(self._parse_ast(self._DOC2))  # type: ignore[arg-type]
+
+        gen_fresh = LaTeXGenerator()
+        latex_fresh = gen_fresh.generate_document(self._parse_ast(self._DOC2))  # type: ignore[arg-type]
+
+        assert latex_reused == latex_fresh
+
+
+# ---------------------------------------------------------------------------
+# Nested CONTENTS: (defect 2)
+# ---------------------------------------------------------------------------
+
+
+class TestNestedContentsDepth:
+    """CONTENTS: inside a Section must still set _toc_depth.
+
+    Verifies that the parser nests the Contents node inside Section.items
+    (structural fact), and that the generator's recursive pre-scan finds it.
+    """
+
+    _SRC = "=== Introduction ===\n\nCONTENTS: 3\n\n** Q1 **\n\n(a) content\n"
+
+    def test_parser_nests_contents_inside_section(self) -> None:
+        # Confirm structural assumption: Contents is inside Section.items.
+        lexer = Lexer(self._SRC)
+        tokens = lexer.tokenize()
+        ast = Parser(tokens).parse()
+        assert isinstance(ast, Document)
+        assert len(ast.items) >= 1
+        section = ast.items[0]
+        assert isinstance(section, Section)
+        contents_nodes = [item for item in section.items if isinstance(item, Contents)]
+        assert len(contents_nodes) == 1
+        assert contents_nodes[0].depth == "3"
+
+    def test_nested_contents_depth3_tocdepth_set(self) -> None:
+        latex = _latex(self._SRC)
+        assert r"\setcounter{tocdepth}{3}" in latex
+
+    def test_nested_contents_depth3_section_present(self) -> None:
+        latex = _latex(self._SRC)
+        assert r"\addcontentsline{toc}{section}{Introduction}" in latex
+
+    def test_nested_contents_depth3_subsubsection_present(self) -> None:
+        # Absent if depth was silently dropped and defaulted to something else.
+        latex = _latex(self._SRC)
+        assert r"\addcontentsline{toc}{subsubsection}{(a)}" in latex

--- a/tests/test_11_text_blocks/test_toc_three_levels.py
+++ b/tests/test_11_text_blocks/test_toc_three_levels.py
@@ -265,34 +265,72 @@ class TestReuseIsolation:
     _DOC1 = "CONTENTS: 1\n\n=== Title ===\n\n** Q1 **\n\n(a) content\n"
     _DOC2 = "=== Title ===\n\n** Q1 **\n\n(a) content\n"
 
-    def _parse_ast(self, src: str) -> object:
+    def _parse_ast(self, src: str) -> Document:
         lexer = Lexer(src)
         tokens = lexer.tokenize()
-        return Parser(tokens).parse()
+        ast = Parser(tokens).parse()
+        assert isinstance(ast, Document)
+        return ast
 
     def test_second_call_subsubsection_present(self) -> None:
         # If depth leaks, this is absent because depth 1 was set by doc1.
         gen = LaTeXGenerator()
-        gen.generate_document(self._parse_ast(self._DOC1))  # type: ignore[arg-type]
-        latex2 = gen.generate_document(self._parse_ast(self._DOC2))  # type: ignore[arg-type]
+        gen.generate_document(self._parse_ast(self._DOC1))
+        latex2 = gen.generate_document(self._parse_ast(self._DOC2))
         assert r"\addcontentsline{toc}{subsubsection}{(a)}" in latex2
 
     def test_second_call_subsection_present(self) -> None:
         gen = LaTeXGenerator()
-        gen.generate_document(self._parse_ast(self._DOC1))  # type: ignore[arg-type]
-        latex2 = gen.generate_document(self._parse_ast(self._DOC2))  # type: ignore[arg-type]
+        gen.generate_document(self._parse_ast(self._DOC1))
+        latex2 = gen.generate_document(self._parse_ast(self._DOC2))
         assert r"\addcontentsline{toc}{subsection}{Q1}" in latex2
 
     def test_second_call_matches_fresh_generator(self) -> None:
         # The reused generator's second output must equal a fresh generator's output.
         gen_reused = LaTeXGenerator()
-        gen_reused.generate_document(self._parse_ast(self._DOC1))  # type: ignore[arg-type]
-        latex_reused = gen_reused.generate_document(self._parse_ast(self._DOC2))  # type: ignore[arg-type]
+        gen_reused.generate_document(self._parse_ast(self._DOC1))
+        latex_reused = gen_reused.generate_document(self._parse_ast(self._DOC2))
 
         gen_fresh = LaTeXGenerator()
-        latex_fresh = gen_fresh.generate_document(self._parse_ast(self._DOC2))  # type: ignore[arg-type]
+        latex_fresh = gen_fresh.generate_document(self._parse_ast(self._DOC2))
 
         assert latex_reused == latex_fresh
+
+
+# ---------------------------------------------------------------------------
+# generate_fragment must resolve TOC depth too (REPL/preview path)
+# ---------------------------------------------------------------------------
+
+
+class TestFragmentTocDepth:
+    """generate_fragment (REPL/preview) must honor CONTENTS: and not leak depth.
+
+    It shares _resolve_toc_depth with generate_document, so CONTENTS: depth is
+    applied and _toc_depth resets per call.
+    """
+
+    _DOC1 = "CONTENTS: 1\n\n=== Title ===\n\n** Q1 **\n\n(a) content\n"
+    _DOC2 = "=== Title ===\n\n** Q1 **\n\n(a) content\n"
+    _DOC3 = "CONTENTS: 3\n\n=== Title ===\n\n** Q1 **\n\n(a) content\n"
+
+    def _parse_ast(self, src: str) -> Document:
+        ast = Parser(Lexer(src).tokenize()).parse()
+        assert isinstance(ast, Document)
+        return ast
+
+    def test_fragment_honors_contents_depth(self) -> None:
+        # CONTENTS: 3 in a fragment must set tocdepth 3 and emit all levels.
+        latex = LaTeXGenerator().generate_fragment(self._parse_ast(self._DOC3))
+        assert r"\setcounter{tocdepth}{3}" in latex
+        assert r"\addcontentsline{toc}{subsubsection}{(a)}" in latex
+
+    def test_fragment_does_not_leak_depth(self) -> None:
+        # Reused generator: depth 1 fragment then a no-CONTENTS fragment must
+        # revert to default 3 (subsubsection present), not leak depth 1.
+        gen = LaTeXGenerator()
+        gen.generate_fragment(self._parse_ast(self._DOC1))
+        latex2 = gen.generate_fragment(self._parse_ast(self._DOC2))
+        assert r"\addcontentsline{toc}{subsubsection}{(a)}" in latex2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Follow-up to #66. A post-merge Copilot review of #66 found two real defects in the `generate_document` TOC pre-scan, plus a stale doc line. Fixes all three.

## Fixes

**1. State leak across reuse** (`latex_gen.py`). `_toc_depth` was only assigned when a `Contents` node was found, so a `LaTeXGenerator` reused for a second `generate_document()` retained the prior document's depth (or the `--toc-parts` bump). The CLI makes a fresh generator per run so it didn't bite there, but it's a latent idempotency bug for library/test reuse. Now reset to default (3) at the start of every call.

**2. Nested `CONTENTS:` ignored** (`latex_gen.py`). The pre-scan walked only top-level `ast.items`, so a `CONTENTS:` directive parsed inside a `Section`/`Solution`/`Part` was dropped — and since `_generate_contents` reads `self._toc_depth` (not `node.depth`), nothing recovered it. Replaced with `_find_contents_depth`, a pre-order DFS that descends into `Section`/`Solution`/`Part` `.items` and returns the first `Contents` depth in document order.

**3. Stale doc** (`USER_GUIDE.md`). The Part Labels line described `(a)\par\vspace{11pt}` — obsolete. Parts render `\subsubsection*{(a)}` in the default subsection mode, inline `(a) ...` under `PARTS: inline`.

## Tests

- `TestReuseIsolation` — one generator, two documents; the second is unaffected by the first and byte-matches a fresh generator.
- `TestNestedContentsDepth` — confirms the parser nests `Contents` inside `Section.items`, and that the nested depth is honored in both `\setcounter{tocdepth}` and the `\addcontentsline` emissions.

`make check` green (4806 passed, 3 expected xfails).

## Note

Process: #66 was merged before Copilot's re-review of the final commit landed (~2.5 min after merge), which is how these reached `main`. Going forward I wait out the bot re-review window after the final fix push before merging.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized TOC state and documentation changes with targeted regression tests; no auth, security, or broad API surface impact.
> 
> **Overview**
> Fixes **table-of-contents depth** handling in `LaTeXGenerator` after issues in the prior TOC work.
> 
> **Generator (`latex_gen.py`):** Replaces the shallow top-level `CONTENTS:` scan with **`_find_contents_depth`** (pre-order DFS into `Section` / `Solution` / `Part` children) and **`_resolve_toc_depth`**, which resets **`_toc_depth` to 3** on every body generation, applies the first `Contents` depth in document order, then honors **`--toc-parts`**. Both **`generate_document`** and **`generate_fragment`** call this path so REPL/preview matches full documents and a reused generator does not leak depth from a prior input.
> 
> **Docs (`USER_GUIDE.md`):** Updates the Part Labels section to describe **`PARTS: subsection`** (`\subsubsection*`) vs **`PARTS: inline`** instead of obsolete `(a)\par\vspace{11pt}` text.
> 
> **Tests:** Adds **`TestReuseIsolation`**, **`TestFragmentTocDepth`**, and **`TestNestedContentsDepth`** covering cross-call isolation, fragment behavior, and `CONTENTS:` nested inside a section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63067cff8aa4a1d1d3a13b080d198e79d148255f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->