### PR TITLE
fix(algebra): no spurious line break after single-line group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   at depth 3 regardless of the `CONTENTS:` keyword in the source file.
   Previously it was the only way to get parts in the TOC at all.
 
+### Fixed
+
+- **Spurious line break after a single-line `group`** — a `group (…)`
+  expression ending a line emitted a stray `\\` (and `\quad`) into the
+  inline math, because the parser treated the end-of-line newline as a
+  continuation. A bare newline now counts as a continuation only when a
+  chaining relational operator (`join`, `div`, `cross`, `group`,
+  `ungroup`) follows on the next line; an explicit trailing `\` still
+  forces the break.
+
 ## [1.6.3] - 2026-05-29
 
 ### Added

--- a/src/txt2tex/parser_pkg/expressions.py
+++ b/src/txt2tex/parser_pkg/expressions.py
@@ -1942,14 +1942,8 @@ class _ExpressionsParser(ParserBase):  # pyright: ignore[reportUnusedClass]
                         self._advance()
                     self._skip_newlines()
                 elif self._match(TokenType.NEWLINE):
+                    has_continuation = self._next_non_newline_is_cross_op()
                     self._skip_newlines()
-                    has_continuation = self._match(
-                        TokenType.CROSS,
-                        TokenType.JOIN,
-                        TokenType.DIV,
-                        TokenType.GROUP,
-                        TokenType.UNGROUP,
-                    )
                 else:
                     self._skip_newlines()
                 if has_continuation:

--- a/src/txt2tex/parser_pkg/expressions.py
+++ b/src/txt2tex/parser_pkg/expressions.py
@@ -1925,7 +1925,15 @@ class _ExpressionsParser(ParserBase):  # pyright: ignore[reportUnusedClass]
                 )
             elif op_token.type == TokenType.GROUP:
                 group_node = self._parse_group_rhs(left, op_token)
-                # Detect line continuation after full GROUP expression
+                # Detect line continuation after full GROUP expression.
+                # Unlike Divide/Join (which check *before* their right
+                # operand), GROUP checks *after* its fully-parsed RHS.
+                # A bare NEWLINE is only a continuation when a chaining
+                # relational operator immediately follows on the next line
+                # (join, div, cross, group, ungroup).  A NEWLINE before
+                # EOF or any non-relational token is just a statement
+                # terminator; treating it as a continuation injects \\
+                # into inline math, producing invalid LaTeX.
                 has_continuation = False
                 if self._match(TokenType.CONTINUATION):
                     self._advance()  # consume \
@@ -1934,8 +1942,14 @@ class _ExpressionsParser(ParserBase):  # pyright: ignore[reportUnusedClass]
                         self._advance()
                     self._skip_newlines()
                 elif self._match(TokenType.NEWLINE):
-                    has_continuation = True
                     self._skip_newlines()
+                    has_continuation = self._match(
+                        TokenType.CROSS,
+                        TokenType.JOIN,
+                        TokenType.DIV,
+                        TokenType.GROUP,
+                        TokenType.UNGROUP,
+                    )
                 else:
                     self._skip_newlines()
                 if has_continuation:

--- a/tests/test_group_no_spurious_linebreak.py
+++ b/tests/test_group_no_spurious_linebreak.py
@@ -1,0 +1,150 @@
+"""Regression tests: single-line GROUP must not emit a spurious line break.
+
+A bare NEWLINE after a GROUP's closing ')' is just the end of the line —
+it is not a continuation marker.  Treating it as one sets line_break_after=True
+on the AST node and the codegen appends ' \\\\\n\\quad ' into inline math,
+producing invalid LaTeX.
+
+See: expressions.py GROUP branch, ~line 1936.
+"""
+
+from __future__ import annotations
+
+from txt2tex.ast_nodes import Document, Expr, GroupAggregate
+from txt2tex.latex_gen import LaTeXGenerator
+from txt2tex.lexer import Lexer
+from txt2tex.parser import Parser
+from txt2tex.tokens import Token
+
+# ---------------------------------------------------------------------------
+# Helpers (mirror the pattern in test_group_aggregators.py)
+# ---------------------------------------------------------------------------
+
+
+def _lex(src: str) -> list[Token]:
+    return Lexer(src).tokenize()
+
+
+def _expr(src: str) -> Expr:
+    result = Parser(_lex(src)).parse()
+    item: Expr = result.items[0] if isinstance(result, Document) else result  # type: ignore[assignment]
+    return item
+
+
+def _expr_latex(src: str) -> str:
+    """Generate LaTeX for a standalone expression (no document wrapper)."""
+    gen = LaTeXGenerator(use_fuzz=True)
+    return gen.generate_expr(_expr(src))
+
+
+def _doc_latex(src: str) -> str:
+    """Generate the full document LaTeX for a complete document source."""
+    tokens = Lexer(src).tokenize()
+    ast = Parser(tokens).parse()
+    return LaTeXGenerator().generate_document(ast)
+
+
+# ---------------------------------------------------------------------------
+# Bug: single-line group with trailing newline must NOT emit \\ or \quad
+# ---------------------------------------------------------------------------
+
+
+def test_single_line_group_aggregate_no_line_break() -> None:
+    r"""R group (Sum(a) as b) followed by \n must not emit \\ or \quad.
+
+    The trailing newline is a statement terminator, not a continuation.
+    """
+    src = "R group (Sum(a) as b)\n"
+    result = _expr_latex(src)
+    assert r"\mathop{\mathrm{Group}}" in result
+    assert r"\\" not in result
+    assert r"\quad" not in result
+
+
+def test_abbreviation_group_aggregate_no_line_break_in_inline_math() -> None:
+    r"""X == R group (Sum(a) as b) in a document must emit $…$ with no \\ inside.
+
+    This is the exact reproduction case from the bug report.
+    """
+    src = "TITLE: probe\n\nX == R group (Sum(a) as b)\n"
+    latex = _doc_latex(src)
+    # The inline-math span must contain the Group operator
+    assert r"$X == R \mathop{\mathrm{Group}}" in latex
+    # A \\ inside inline math is invalid — must not appear
+    assert r"\\" not in latex
+    assert r"\quad" not in latex
+
+
+def test_two_aggregate_single_line_no_line_break() -> None:
+    r"""R group (Sum(a) as b, Sum(c) as d) on one line must not emit \\."""
+    src = "R group (Sum(a) as b, Sum(c) as d)\n"
+    result = _expr_latex(src)
+    assert r"\mathop{\mathrm{Group}}" in result
+    assert r"\\" not in result
+    assert r"\quad" not in result
+
+
+def test_regroup_form_single_line_no_line_break() -> None:
+    r"""R group ({a, b} as g) on one line must not emit \\."""
+    src = "R group ({a, b} as g)\n"
+    result = _expr_latex(src)
+    assert r"\mathop{\mathrm{GROUP}}" in result
+    assert r"\\" not in result
+    assert r"\quad" not in result
+
+
+# ---------------------------------------------------------------------------
+# AST: line_break_after must be False for plain single-line group
+# ---------------------------------------------------------------------------
+
+
+def test_single_line_group_aggregate_ast_no_line_break_flag() -> None:
+    """Parsing a single-line group sets line_break_after=False on the AST node."""
+    src = "R group (Sum(a) as b)\n"
+    node = _expr(src)
+    assert isinstance(node, GroupAggregate)
+    assert node.line_break_after is False
+
+
+# ---------------------------------------------------------------------------
+# Regression: explicit CONTINUATION token after ) still sets the break
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_continuation_after_group_still_breaks() -> None:
+    r"""An explicit backslash continuation after GROUP's ')' still sets \\."""
+    # Source: "R group (Sum(a) as b) \<newline>"  — the \ is the CONTINUATION token
+    src = "R group (Sum(a) as b) \\\n"
+    result = _expr_latex(src)
+    assert r"\mathop{\mathrm{Group}}" in result
+    assert r"\\" in result
+
+
+def test_explicit_continuation_ast_line_break_flag_true() -> None:
+    r"""Explicit \ continuation after GROUP sets line_break_after=True on the AST."""
+    src = "R group (Sum(a) as b) \\\n"
+    node = _expr(src)
+    assert isinstance(node, GroupAggregate)
+    assert node.line_break_after is True
+
+
+# ---------------------------------------------------------------------------
+# Non-group regressions: join and project are unaffected
+# ---------------------------------------------------------------------------
+
+
+def test_join_single_line_unaffected() -> None:
+    r"""R join S on a single line: no spurious \\ added by this fix."""
+    src = "R join S\n"
+    result = _expr_latex(src)
+    assert r"\mathrm{Join}" in result
+    # A single-line join should not have a line break injected
+    assert r"\\" not in result
+
+
+def test_project_single_line_unaffected() -> None:
+    r"""pi [a, b] R on a single line: no spurious \\ added by this fix."""
+    src = "pi [a, b] R\n"
+    result = _expr_latex(src)
+    # Project emits \pi or \Pi; confirm no stray line break
+    assert r"\\" not in result


### PR DESCRIPTION
## What

A single-line relational-algebra `group (…)` expression emitted a stray `\\` and `\quad` into the inline math, e.g.:

```
$X == R \mathop{\mathrm{Group}}(\mathrm{Sum}(a)~\mathrm{as}~b) \\
\quad $
```

The `\\` is invalid inside inline `$…$` and produced odd vertical spacing.

## Cause

In `parser_pkg/expressions.py`, the GROUP branch of the operator loop parses the **entire** `group (…)` RHS, then checks the next token for a continuation. A bare end-of-line `NEWLINE` was treated as a continuation, setting `line_break_after=True`; the codegen then appended ` \\\n\quad `.

This differs from `Divide`/`Join`, which check for a continuation *before* their right operand — there a newline genuinely means "operand continues on the next line." GROUP checks *after* its full expression, so a bare newline is just a statement terminator.

## Fix

In the GROUP branch only, a bare newline counts as a continuation **only when a chaining relational operator follows** (`join`, `div`, `cross`, `group`, `ungroup`). An explicit trailing `\` still forces the break. No other operator branch is touched.

## Tests (`tests/test_group_no_spurious_linebreak.py`)

- Single-line group — aggregate, two-aggregate, and regroup forms — emit no `\\`/`\quad`.
- AST `line_break_after` is `False` for a plain single-line group.
- Explicit `\` continuation still sets the break (LaTeX + AST).
- `join`/`project` single lines unaffected.

`make check` green (4817 passed, 3 expected xfails). Verified on the originating assignment: the `Group` lines now close cleanly with `$`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized parser change in the GROUP continuation path with targeted regression tests; join/div behavior unchanged except the intended GROUP fix.
> 
> **Overview**
> Fixes invalid inline LaTeX when a **`group (…)`** expression ends a line: the parser no longer treats a bare trailing newline as a line continuation after the full `group` RHS.
> 
> **Parser (`expressions.py`, GROUP branch only):** After parsing `group (…)`, a newline sets `line_break_after` only if the next non-blank token is a chaining relational operator (`join`, `div`, `cross`, `group`, `ungroup`) via `_next_non_newline_is_cross_op()`. An explicit `\` continuation still forces a break. This avoids codegen emitting `\\` and `\quad` inside `$…$` for statement-ending lines like `R group (Sum(a) as b)`.
> 
> **Tests:** New `tests/test_group_no_spurious_linebreak.py` covers aggregate/regroup single-line forms, abbreviation inline math, AST flags, explicit `\` continuation, and sanity checks for `join`/`pi`.
> 
> **CHANGELOG:** Documents the fix under Unreleased → Fixed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 263f606f8d4fe286b3a014672666e8f42eaf619b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->