### PR TITLE
feat(algebra): add extend operator and two-argument aggregates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`extend` operator and two-argument aggregates** — Date's `EXTEND` for
+  adding a per-tuple computed attribute, plus the two-argument aggregate
+  `Agg(rel, attr)` (e.g. `Sum(payments, amountPaid)`) for summarising a
+  relation-valued attribute produced by `group ({…} as rva)`.
+  `R extend (Sum(payments, amountPaid) as total)` renders
+  `R \mathop{\mathrm{Extend}}(\mathrm{Sum}(payments, amountPaid)~\mathrm{as}~total)`.
+  The single-argument aggregate form is unchanged. Relational-algebra
+  constructs (including `extend`) render as inline math and are not
+  fuzz type-checked.
+
 ### Changed
 
 - **`** **` solutions now render `\subsection*`** — previously `\section*`.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -3055,3 +3055,44 @@ for a homework section divider.
 - The `full` keyword alias is a convenience for users who want everything
   in the TOC without remembering the number 3.  It replaces the previous
   meaning of `full` (which was depth 2).
+
+## ADR: EXTEND operator and two-argument aggregates
+
+**Status**: SETTLED 2026-07-01.
+
+**Context.**  The relational-algebra family supported single-argument
+aggregates inside `group` (e.g. `R group (Sum(x) as t)`), which group by
+the complement of the named attribute (SUMMARIZE semantics).  It could not
+aggregate a *relation-valued attribute* (RVA) produced by the regroup form
+`R group ({A, B} as rva)`.  This matters because summing a projected
+attribute deduplicates equal values under set semantics and undercounts —
+two equal payments on one invoice collapse to a single row before `Sum`.
+Preserving multiplicity requires nesting the distinct tuples (carrying
+their key) and aggregating the RVA.
+
+**Decision.**
+
+1. **Two-argument aggregate** `Agg(rel, attr)` — Date's aggregate-operator
+   form `SUM(r, exp)`, with the second argument restricted to an attribute
+   name.  Renders `\mathrm{Sum}(payments, amountPaid)`.  The single-argument
+   form is unchanged; two arguments is a distinct arity of the same clause.
+2. **`extend` operator** — Date's `EXTEND`, adding a per-tuple scalar.
+   `R extend (Sum(rva, attr) as alias)` renders
+   `R \mathop{\mathrm{Extend}}(\mathrm{Sum}(rva, attr)~\mathrm{as}~alias)`.
+
+**Rejected alternative.**  Allow the two-argument aggregate inside `group`
+only, with no `extend`.  Rejected because aggregating an RVA per tuple is
+EXTEND, not GROUP: GROUP *produces* an RVA and reduces cardinality; EXTEND
+*consumes* an RVA and preserves it.  Rendering the operation under `Group`
+mislabels it, and the course teaches Date's algebra where the distinction
+is real.  Reviewed by jms (2026-07-01).
+
+**Consequences.**
+
+- `extend` is a new reserved keyword; relational-algebra documents can now
+  express multiplicity-preserving aggregation correctly.
+- `ExtendAggregate` is in the DAT expression set, so `extend` renders as
+  inline math and is never routed into a fuzz-checked `zed` block (per the
+  `cross` fuzz-routing fix).
+- The course did not teach `extend`, so its use is a per-document choice;
+  single-argument `group` aggregation is unaffected.

--- a/docs/guides/USER_GUIDE.md
+++ b/docs/guides/USER_GUIDE.md
@@ -3174,6 +3174,81 @@ GROUP and UNGROUP are left-associative at the same precedence as
 R group ({A} as sub) ungroup sub
 ```
 
+#### Two-argument aggregate form
+
+The aggregators (`Count`, `Sum`, `Avg`, `Min`, `Max`, `Median`) accept
+a second argument when you want to aggregate a specific attribute over
+a **relation-valued attribute** (RVA) rather than grouping by its
+complement.
+
+```text
+Sum(payments, amountPaid)
+```
+
+Renders: $\mathrm{Sum}(payments, amountPaid)$
+
+The first argument names the RVA column; the second names the scalar
+attribute inside it to aggregate.  The second argument must be a plain
+attribute identifier — not a general expression.
+
+The two-argument form is accepted in any aggregate clause, but its
+correct home is `extend` (see below): aggregating a relation-valued
+attribute per tuple is Date's EXTEND, not GROUP.  The single-argument
+form `Sum(attr)` inside `group` is unchanged.
+
+#### EXTEND
+
+Date's EXTEND operator adds a per-tuple computed attribute to a
+relation.  Each clause applies a two-argument aggregate to an existing
+RVA column and names the resulting scalar attribute.
+
+```text
+R extend (Agg(rva, attr) as alias)
+R extend (Agg(rva, attr) as alias, Agg2(rva2, attr2) as alias2)
+```
+
+Example:
+
+```text
+InvPayGrouped extend (Sum(payments, amountPaid) as totalInvoicePayment)
+```
+
+Renders: $InvPayGrouped \mathop{\mathrm{Extend}}(\mathrm{Sum}(payments, amountPaid)~\mathrm{as}~totalInvoicePayment)$
+
+Multiple comma-separated clauses are allowed:
+
+```text
+R extend (Sum(payments, amountPaid) as total, Count(payments, paymentId) as n)
+```
+
+**When to use `extend` vs `group`.**
+
+| Operator | Effect | Cardinality |
+|----------|--------|-------------|
+| `R group ({A, B} as rva)` | Nests columns `A, B` into an RVA | Reduces (one row per key) |
+| `R extend (Agg(rva, attr) as alias)` | Adds a scalar computed from an existing RVA | Preserves (same number of rows) |
+
+**Why nest-then-extend instead of project-then-aggregate.**
+
+Under set semantics, projecting to `(key, amount)` deduplicates equal
+values — two payments of the same amount for the same invoice collapse
+to one row, and a subsequent sum undercounts.  Nesting the distinct
+tuples (which carry their own key) into an RVA preserves multiplicity,
+so the aggregate is correct.
+
+Worked example:
+
+```text
+InvPayGrouped == Payment group ({paymentId, amountPaid} as payments)
+PaidPerInv    == InvPayGrouped extend (Sum(payments, amountPaid) as totalInvoicePayment)
+```
+
+`InvPayGrouped` nests each payment tuple (with its own `paymentId`) into
+the `payments` RVA, one row per invoice.  `PaidPerInv` then sums the
+`amountPaid` values inside each nested relation, producing a correct
+total per invoice.  The result renders inline — relational algebra is
+not fuzz type-checked.
+
 ### Z Binding Calculus (Phase 2.3)
 
 Binding brackets construct labelled tuples per Z RM §3.7.  Used in

--- a/src/txt2tex/ast_nodes.py
+++ b/src/txt2tex/ast_nodes.py
@@ -691,15 +691,19 @@ class Aggregator(Enum):
 
 @dataclass(frozen=True)
 class AggregatorClause(ASTNode):
-    """Single aggregator application inside a GROUP aggregate expression.
+    """Single aggregator application inside a GROUP or EXTEND expression.
 
-    Represents ``Count(attr) as alias``.  The rendered form is
-    ``\\mathrm{Count}(attr)~\\mathrm{as}~alias``.
+    Represents ``Count(attr) as alias`` (single-arg form) or
+    ``Sum(rel, attr) as alias`` (two-arg Date form).
+
+    Single-arg rendered form: ``\\mathrm{Count}(attr)~\\mathrm{as}~alias``.
+    Two-arg rendered form:    ``\\mathrm{Sum}(rel, attr)~\\mathrm{as}~alias``.
     """
 
     agg: Aggregator
     attr: str  # Single attribute identifier (no nested expressions)
     alias: str  # Name the aggregated column receives in the output relation
+    source_rel: str | None = None  # Two-arg form: relation-valued attribute (Date)
 
 
 # Relational algebra nodes (Phase 2.2)
@@ -872,6 +876,35 @@ class GroupAggregate(ASTNode):
 
 
 @dataclass(frozen=True)
+class ExtendAggregate(ASTNode):
+    """Date's EXTEND operator — add computed aggregate attributes (Phase 4.3).
+
+    Represents ``R extend (Sum(payments, amountPaid) as totalInvoicePayment)``.
+
+    Computes one or more scalar aggregates and appends them as new attributes
+    to every tuple in R.  Each aggregator clause names the aggregation
+    function, optionally the source relation-valued attribute, the input
+    attribute, and the output alias.
+
+    Examples:
+    - R extend (Count(x) as n)
+      -> relation=Identifier("R"), clauses=[AggregatorClause(COUNT, "x", "n")]
+    - R extend (Sum(payments, amountPaid) as total)
+      -> relation=Identifier("R"),
+         clauses=[AggregatorClause(SUM, "amountPaid", "total", source_rel="payments")]
+
+    LaTeX rendering::
+
+      R \\mathop{\\mathrm{Extend}}(
+          \\mathrm{Sum}(payments, amountPaid)~\\mathrm{as}~total)
+    """
+
+    relation: Expr
+    clauses: list[AggregatorClause]
+    line_break_after: bool = False
+
+
+@dataclass(frozen=True)
 class Binding(ASTNode):
     r"""Z binding expression (Z RM §3.7).
 
@@ -936,6 +969,7 @@ Expr = (
     | Group
     | Ungroup
     | GroupAggregate
+    | ExtendAggregate
     | Binding
 )
 

--- a/src/txt2tex/codegen/algebra.py
+++ b/src/txt2tex/codegen/algebra.py
@@ -17,6 +17,7 @@ from txt2tex.ast_nodes import (
     AggregatorClause,
     Divide,
     Expr,
+    ExtendAggregate,
     Group,
     GroupAggregate,
     Identifier,
@@ -197,12 +198,48 @@ class _AlgebraCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
     def _generate_aggregator_clause(self, clause: AggregatorClause) -> str:
         r"""Render a single AggregatorClause as LaTeX.
 
-        Count(attr) as alias  →  \mathrm{Count}(attr)~\mathrm{as}~alias
+        Single-arg: Count(attr) as alias  →  \mathrm{Count}(attr)~\mathrm{as}~alias
+        Two-arg:    Sum(rel, attr) as alias → \mathrm{Sum}(rel, attr)~\mathrm{as}~alias
         """
         label = clause.agg.label()
         attr = self._emit_attr_name(clause.attr)
         alias = self._emit_attr_name(clause.alias)
-        return rf"\mathrm{{{label}}}({attr})~\mathrm{{as}}~{alias}"
+        if clause.source_rel is not None:
+            rel = self._emit_attr_name(clause.source_rel)
+            args = f"{rel}, {attr}"
+        else:
+            args = attr
+        return rf"\mathrm{{{label}}}({args})~\mathrm{{as}}~{alias}"
+
+    @expr_register.register(ExtendAggregate)
+    def _generate_extend_aggregate(
+        self, node: ExtendAggregate, parent: Expr | None = None
+    ) -> str:
+        r"""Generate LaTeX for R extend (Sum(payments, amountPaid) as total).
+
+        Each AggregatorClause renders as:
+            \mathrm{Sum}(payments, amountPaid)~\mathrm{as}~total
+
+        The full expression renders as:
+            R \mathop{\mathrm{Extend}}(
+                \mathrm{Sum}(payments, amountPaid)~\mathrm{as}~total)
+
+        The ``\mathop`` wrapper gives ``Extend`` proper binary-operator spacing
+        in math mode so the left operand does not collide with the operator symbol.
+        Consistent with ``_generate_group_aggregate`` which uses ``\mathop`` for
+        the same reason.
+
+        When line_break_after is set, inserts \\ after the EXTEND expression.
+        """
+        relation_latex = self.generate_expr(node.relation)
+        clause_parts = ", ".join(
+            self._generate_aggregator_clause(c) for c in node.clauses
+        )
+        result = rf"{relation_latex} \mathop{{\mathrm{{Extend}}}}({clause_parts})"
+        if node.line_break_after:
+            indent = self._get_indentation()
+            return f"{result} \\\\\n{indent} "
+        return result
 
     @expr_register.register(Ungroup)
     def _generate_ungroup(self, node: Ungroup, parent: Expr | None = None) -> str:

--- a/src/txt2tex/codegen/fuzz_routing.py
+++ b/src/txt2tex/codegen/fuzz_routing.py
@@ -19,6 +19,7 @@ from txt2tex.ast_nodes import (
     Binding,
     Divide,
     Expr,
+    ExtendAggregate,
     Group,
     GroupAggregate,
     Identifier,
@@ -45,6 +46,7 @@ class _FuzzRoutingCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass
         Binding,
         Group,
         GroupAggregate,
+        ExtendAggregate,
         Ungroup,
     )
 

--- a/src/txt2tex/codegen/fuzz_routing.py
+++ b/src/txt2tex/codegen/fuzz_routing.py
@@ -1,6 +1,6 @@
 """Fuzz-vs-inline-math routing helpers.
 
-Some AST nodes — algebra, bindings, GROUP/UNGROUP — cannot sit inside
+Some AST nodes — algebra, bindings, GROUP/UNGROUP/EXTEND — cannot sit inside
 a Z environment because fuzz rejects their syntax.  Abbreviation
 emission inspects the right-hand side and switches between an in-Z
 form (``\begin{zed}...\\end{zed}``) and a noindent inline-math form

--- a/src/txt2tex/lexer.py
+++ b/src/txt2tex/lexer.py
@@ -32,9 +32,10 @@ KEYWORD_TO_TOKEN: dict[str, TokenType] = {
     "pi": TokenType.PI,
     "join": TokenType.JOIN,
     "div": TokenType.DIV,
-    # Nested-relation operators (Phase 4.1)
+    # Nested-relation operators (Phase 4.1 / 4.3)
     "group": TokenType.GROUP,
     "ungroup": TokenType.UNGROUP,
+    "extend": TokenType.EXTEND,
     # Aggregator keywords (Phase 4.2)
     "Count": TokenType.COUNT,
     "Sum": TokenType.SUM,
@@ -122,6 +123,7 @@ RESERVED_WORDS: frozenset[str] = frozenset(
         "div",
         "group",
         "ungroup",
+        "extend",
         # --- Aggregator keywords (Phase 4.2) ---
         "Count",
         "Sum",

--- a/src/txt2tex/parser.py
+++ b/src/txt2tex/parser.py
@@ -585,6 +585,7 @@ class Parser(
             TokenType.FILTER,  # filter (sequence filter)
             TokenType.GROUP,  # group (relational operator; legal as attr name)
             TokenType.UNGROUP,  # ungroup (relational operator; legal as attr name)
+            TokenType.EXTEND,  # extend (relational operator; legal as attr name)
         )
 
     # Operator keywords whose LaTeX expansion (e.g. \id, \dom) collides

--- a/src/txt2tex/parser_pkg/_base.py
+++ b/src/txt2tex/parser_pkg/_base.py
@@ -53,6 +53,7 @@ if TYPE_CHECKING:
         Declaration,
         DocumentItem,
         Expr,
+        ExtendAggregate,
         FreeBranch,
         FreeType,
         GenDef,
@@ -191,6 +192,9 @@ class ParserBase:
         ) -> GroupAggregate: ...
         def _parse_aggregator_clause(self) -> object: ...
         def _parse_ungroup_rhs(self, relation: Expr, ungroup_tok: Token) -> Ungroup: ...
+        def _parse_extend_aggregate_rhs(
+            self, relation: Expr, extend_tok: Token
+        ) -> ExtendAggregate: ...
 
         # --- Schema parsers (Move 13) ---
         def _parse_schema_pipe(self) -> Expr: ...

--- a/src/txt2tex/parser_pkg/algebra.py
+++ b/src/txt2tex/parser_pkg/algebra.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from txt2tex.ast_nodes import (
     AggregatorClause,
     Expr,
+    ExtendAggregate,
     Group,
     GroupAggregate,
     Project,
@@ -144,7 +145,12 @@ class _AlgebraParser(ParserBase):  # pyright: ignore[reportUnusedClass]
         )
 
     def _parse_aggregator_clause(self) -> AggregatorClause:
-        """Parse a single ``Count(attr) as alias`` clause."""
+        """Parse a single ``Count(attr) as alias`` or ``Sum(rel, attr) as alias``.
+
+        The two-arg form (Date SUM(rel, exp)) is accepted when a COMMA follows
+        the first identifier inside the parens.  First arg becomes ``source_rel``,
+        second arg becomes ``attr``.  Single-arg form leaves ``source_rel=None``.
+        """
         agg_tok = self._current()
         if agg_tok.type not in self._AGGREGATOR_TOKEN_TYPES:
             raise ParserError(
@@ -165,7 +171,21 @@ class _AlgebraParser(ParserBase):  # pyright: ignore[reportUnusedClass]
                 f"Expected attribute name inside '{agg_tok.value}(...)'",
                 self._current(),
             )
-        attr = self._advance().value
+        first = self._advance().value
+        # Two-arg form: Agg(source_rel, attr) as alias
+        source_rel: str | None = None
+        if self._match(TokenType.COMMA):
+            self._advance()  # consume ','
+            if not self._is_attr_name_token():
+                msg = (
+                    f"Expected attribute name after ',' "
+                    f"in '{agg_tok.value}({first}, ...)'"
+                )
+                raise ParserError(msg, self._current())
+            source_rel = first
+            attr = self._advance().value
+        else:
+            attr = first
         if not self._match(TokenType.RPAREN):
             raise ParserError(
                 f"Expected ')' after attribute in '{agg_tok.value}({attr})'",
@@ -190,6 +210,7 @@ class _AlgebraParser(ParserBase):  # pyright: ignore[reportUnusedClass]
             agg=agg,
             attr=attr,
             alias=alias,
+            source_rel=source_rel,
             line=agg_tok.line,
             column=agg_tok.column,
         )
@@ -208,6 +229,35 @@ class _AlgebraParser(ParserBase):  # pyright: ignore[reportUnusedClass]
             alias=alias,
             line=ungroup_tok.line,
             column=ungroup_tok.column,
+        )
+
+    def _parse_extend_aggregate_rhs(
+        self, relation: Expr, extend_tok: Token
+    ) -> ExtendAggregate:
+        """Parse the RHS of an EXTEND expression.
+
+        Called after the 'extend' keyword has been consumed.  Expects
+        ``( clause, clause, ... )`` where each clause is an aggregator
+        clause (single- or two-arg form).
+        """
+        if not self._match(TokenType.LPAREN):
+            raise ParserError("Expected '(' after 'extend'", self._current())
+        self._advance()  # consume '('
+        clauses: list[AggregatorClause] = []
+        clauses.append(self._parse_aggregator_clause())
+        while self._match(TokenType.COMMA):
+            self._advance()  # consume ','
+            clauses.append(self._parse_aggregator_clause())
+        if not self._match(TokenType.RPAREN):
+            raise ParserError(
+                "Expected ')' to close 'extend' expression", self._current()
+            )
+        self._advance()  # consume ')'
+        return ExtendAggregate(
+            relation=relation,
+            clauses=clauses,
+            line=extend_tok.line,
+            column=extend_tok.column,
         )
 
     def _parse_restrict(self) -> Restrict:

--- a/src/txt2tex/parser_pkg/expressions.py
+++ b/src/txt2tex/parser_pkg/expressions.py
@@ -25,6 +25,7 @@ from txt2tex.ast_nodes import (
     Conditional,
     Divide,
     Expr,
+    ExtendAggregate,
     FunctionApp,
     GenericInstantiation,
     Group,
@@ -1851,6 +1852,7 @@ class _ExpressionsParser(ParserBase):  # pyright: ignore[reportUnusedClass]
             TokenType.DIV,
             TokenType.GROUP,
             TokenType.UNGROUP,
+            TokenType.EXTEND,
         ):
             op_token = self._advance()
 
@@ -1993,6 +1995,8 @@ class _ExpressionsParser(ParserBase):  # pyright: ignore[reportUnusedClass]
                     )
                 else:
                     left = ungroup_node
+            elif op_token.type == TokenType.EXTEND:
+                left = self._parse_extend_full(left, op_token)
             else:
                 # CROSS
                 has_continuation = False
@@ -2023,18 +2027,7 @@ class _ExpressionsParser(ParserBase):  # pyright: ignore[reportUnusedClass]
             #            join T
             # The just-constructed node gets line_break_after=True so the
             # caller knows to emit \\ before the next operator.
-            if self._match(TokenType.CONTINUATION):
-                self._advance()  # consume \
-                if self._match(TokenType.NEWLINE):
-                    self._advance()
-                self._skip_newlines()
-                left = dataclasses.replace(left, line_break_after=True)
-            elif (
-                self._match(TokenType.NEWLINE) and self._next_non_newline_is_cross_op()
-            ):
-                # Natural line break before another cross-level operator
-                self._skip_newlines()
-                left = dataclasses.replace(left, line_break_after=True)
+            left = self._apply_trailing_continuation(left)
 
         return left
 
@@ -2055,7 +2048,55 @@ class _ExpressionsParser(ParserBase):  # pyright: ignore[reportUnusedClass]
             TokenType.DIV,
             TokenType.GROUP,
             TokenType.UNGROUP,
+            TokenType.EXTEND,
         )
+
+    def _parse_extend_full(self, left: Expr, op_token: Token) -> Expr:
+        """Parse an extend expression and handle post-expression line continuation.
+
+        Mirrors the GROUP branch continuation logic: a bare NEWLINE only sets
+        line_break_after when a chaining relational operator follows immediately.
+        """
+        extend_node = self._parse_extend_aggregate_rhs(left, op_token)
+        has_continuation = False
+        if self._match(TokenType.CONTINUATION):
+            self._advance()  # consume \
+            has_continuation = True
+            if self._match(TokenType.NEWLINE):
+                self._advance()
+            self._skip_newlines()
+        elif self._match(TokenType.NEWLINE):
+            has_continuation = self._next_non_newline_is_cross_op()
+            self._skip_newlines()
+        else:
+            self._skip_newlines()
+        if has_continuation:
+            return ExtendAggregate(
+                relation=extend_node.relation,
+                clauses=extend_node.clauses,
+                line_break_after=True,
+                line=extend_node.line,
+                column=extend_node.column,
+            )
+        return extend_node
+
+    def _apply_trailing_continuation(self, left: Expr) -> Expr:
+        """Apply trailing continuation marker after a cross-level operator.
+
+        Checks for a ``\\`` or natural newline-before-cross-op pattern after
+        the just-constructed node.  Returns left with line_break_after=True
+        if a continuation was detected, otherwise returns left unchanged.
+        """
+        if self._match(TokenType.CONTINUATION):
+            self._advance()  # consume \
+            if self._match(TokenType.NEWLINE):
+                self._advance()
+            self._skip_newlines()
+            return dataclasses.replace(left, line_break_after=True)  # type: ignore[arg-type]
+        if self._match(TokenType.NEWLINE) and self._next_non_newline_is_cross_op():
+            self._skip_newlines()
+            return dataclasses.replace(left, line_break_after=True)  # type: ignore[arg-type]
+        return left
 
     # Token types that start an aggregator clause.
     _AGGREGATOR_TOKEN_TYPES: ClassVar[frozenset[TokenType]] = frozenset(

--- a/src/txt2tex/parser_pkg/expressions.py
+++ b/src/txt2tex/parser_pkg/expressions.py
@@ -25,7 +25,6 @@ from txt2tex.ast_nodes import (
     Conditional,
     Divide,
     Expr,
-    ExtendAggregate,
     FunctionApp,
     GenericInstantiation,
     Group,
@@ -2071,13 +2070,7 @@ class _ExpressionsParser(ParserBase):  # pyright: ignore[reportUnusedClass]
         else:
             self._skip_newlines()
         if has_continuation:
-            return ExtendAggregate(
-                relation=extend_node.relation,
-                clauses=extend_node.clauses,
-                line_break_after=True,
-                line=extend_node.line,
-                column=extend_node.column,
-            )
+            return dataclasses.replace(extend_node, line_break_after=True)
         return extend_node
 
     def _apply_trailing_continuation(self, left: Expr) -> Expr:

--- a/src/txt2tex/parser_pkg/expressions.py
+++ b/src/txt2tex/parser_pkg/expressions.py
@@ -1834,12 +1834,13 @@ class _ExpressionsParser(ParserBase):  # pyright: ignore[reportUnusedClass]
         return left
 
     def _parse_cross(self) -> Expr:
-        """Parse Cartesian product, natural join, theta-join, division, GROUP, UNGROUP.
+        """Parse product, join, division, GROUP, UNGROUP, and EXTEND.
 
-        CROSS, JOIN, DIV, GROUP, and UNGROUP sit at the same precedence
-        level between set operators and arithmetic (Phase 2.2 / 4.1).
+        CROSS, JOIN, DIV, GROUP, UNGROUP, and EXTEND sit at the same
+        precedence level between set operators and arithmetic (Phase 2.2 / 4.1).
         JOIN handles an optional subscript bracket: R join [p] S.
-        GROUP and UNGROUP are Date's nested-relation operators.
+        GROUP and UNGROUP are Date's nested-relation operators; EXTEND adds
+        a per-tuple computed attribute.
 
         Supports multi-line expressions with natural line breaks.
         """
@@ -2034,7 +2035,7 @@ class _ExpressionsParser(ParserBase):  # pyright: ignore[reportUnusedClass]
         """Peek ahead past newlines to see if a cross-level operator follows.
 
         Returns True when the next non-newline token is one of CROSS, JOIN,
-        DIV, GROUP, or UNGROUP, indicating a natural line break in a chain.
+        DIV, GROUP, UNGROUP, or EXTEND, indicating a natural line break in a chain.
         """
         pos = self.pos
         while pos < len(self.tokens) and self.tokens[pos].type == TokenType.NEWLINE:

--- a/src/txt2tex/tokens.py
+++ b/src/txt2tex/tokens.py
@@ -170,9 +170,10 @@ class TokenType(Enum):
     LBIND = auto()  # {| (binding literal left)
     RBIND = auto()  # |} (binding literal right)
 
-    # Nested-relation operators (Phase 4.1 — Date's GROUP / UNGROUP)
+    # Nested-relation operators (Phase 4.1 — Date's GROUP / UNGROUP / EXTEND)
     GROUP = auto()  # group (bundle attributes into nested relation)
     UNGROUP = auto()  # ungroup (flatten nested relation)
+    EXTEND = auto()  # extend (add computed attributes to a relation)
 
     # Aggregator keywords (Phase 4.2 — GROUP aggregate form)
     COUNT = auto()  # Count (aggregate count of values)

--- a/tests/test_extend_aggregate.py
+++ b/tests/test_extend_aggregate.py
@@ -1,0 +1,285 @@
+"""Tests for extend operator and two-argument aggregate form.
+
+Features under test:
+- Two-arg aggregator: Agg(rel, attr) as alias  (Date SUM(rel, exp) form)
+- extend operator: R extend (Agg(...) as alias, ...)
+- Fuzz routing: extend abbreviation goes to inline math, not zed
+- Regression: single-arg aggregate and group output unchanged
+"""
+
+from __future__ import annotations
+
+from txt2tex.ast_nodes import (
+    Abbreviation,
+    Aggregator,
+    Document,
+    Expr,
+    ExtendAggregate,
+    GroupAggregate,
+    Identifier,
+)
+from txt2tex.latex_gen import LaTeXGenerator
+from txt2tex.lexer import RESERVED_WORDS, Lexer
+from txt2tex.parser import Parser
+from txt2tex.tokens import Token, TokenType
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _lex(src: str) -> list[Token]:
+    """Tokenize src."""
+    return Lexer(src).tokenize()
+
+
+def _expr(src: str) -> Expr:
+    """Parse a single expression and return the first document item."""
+    result = Parser(_lex(src)).parse()
+    item: Expr = result.items[0] if isinstance(result, Document) else result  # type: ignore[assignment]
+    return item
+
+
+def _expr_latex(src: str) -> str:
+    """Generate LaTeX for an expression (math content without document wrapper)."""
+    gen = LaTeXGenerator(use_fuzz=True)
+    item = _expr(src)
+    return gen.generate_expr(item)
+
+
+def _doc_latex(src: str) -> str:
+    """Generate LaTeX for a full document source string."""
+    tokens = Lexer(src).tokenize()
+    ast = Parser(tokens).parse()
+    return LaTeXGenerator().generate_document(ast)
+
+
+# ---------------------------------------------------------------------------
+# Lexer: extend keyword
+# ---------------------------------------------------------------------------
+
+
+def test_lex_extend_token() -> None:
+    """extend is lexed as EXTEND token, not IDENTIFIER."""
+    tokens = _lex("extend")
+    assert tokens[0].type == TokenType.EXTEND
+
+
+def test_extend_in_reserved_words() -> None:
+    """extend appears in RESERVED_WORDS."""
+    assert "extend" in RESERVED_WORDS
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Two-arg aggregate parse
+# ---------------------------------------------------------------------------
+
+
+def test_two_arg_agg_parse_sum() -> None:
+    """R group (Sum(a, b) as t) -> AggregatorClause(SUM, source_rel='a', attr='b')."""
+    node = _expr("R group (Sum(a, b) as t)")
+    assert isinstance(node, GroupAggregate)
+    assert len(node.clauses) == 1
+    clause = node.clauses[0]
+    assert clause.agg == Aggregator.SUM
+    assert clause.source_rel == "a"
+    assert clause.attr == "b"
+    assert clause.alias == "t"
+
+
+def test_two_arg_agg_parse_count() -> None:
+    """R group (Count(rel, x) as total) -> source_rel='rel', attr='x'."""
+    node = _expr("R group (Count(rel, x) as total)")
+    assert isinstance(node, GroupAggregate)
+    clause = node.clauses[0]
+    assert clause.agg == Aggregator.COUNT
+    assert clause.source_rel == "rel"
+    assert clause.attr == "x"
+    assert clause.alias == "total"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Two-arg aggregate render
+# ---------------------------------------------------------------------------
+
+
+def test_two_arg_agg_render_sum() -> None:
+    r"""Two-arg Sum renders as \mathrm{Sum}(a, b)~\mathrm{as}~t."""
+    result = _expr_latex("R group (Sum(a, b) as t)")
+    assert r"\mathrm{Sum}(a, b)~\mathrm{as}~t" in result
+
+
+def test_two_arg_agg_render_full_date_example() -> None:
+    r"""Date example: Sum(payments, amountPaid) as totalInvoicePayment."""
+    result = _expr_latex("R group (Sum(payments, amountPaid) as totalInvoicePayment)")
+    assert (
+        r"\mathrm{Sum}(payments, amountPaid)~\mathrm{as}~totalInvoicePayment" in result
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Single-arg aggregate unchanged (regression)
+# ---------------------------------------------------------------------------
+
+
+def test_single_arg_agg_source_rel_is_none() -> None:
+    """R group (Sum(x) as t) -> source_rel is None."""
+    node = _expr("R group (Sum(x) as t)")
+    assert isinstance(node, GroupAggregate)
+    clause = node.clauses[0]
+    assert clause.source_rel is None
+    assert clause.attr == "x"
+    assert clause.alias == "t"
+
+
+def test_single_arg_agg_render_unchanged() -> None:
+    r"""Single-arg Sum still renders as \mathrm{Sum}(x)~\mathrm{as}~t."""
+    result = _expr_latex("R group (Sum(x) as t)")
+    assert r"\mathrm{Sum}(x)~\mathrm{as}~t" in result
+    assert r"\mathrm{Sum}(x, " not in result
+
+
+def test_single_arg_count_render_unchanged() -> None:
+    r"""Regression: Count(x) as total renders as \mathrm{Count}(x)~\mathrm{as}~total."""
+    result = _expr_latex("R group (Count(x) as total)")
+    assert r"\mathrm{Count}(x)~\mathrm{as}~total" in result
+    assert r"\mathop{\mathrm{Group}}" in result
+
+
+# ---------------------------------------------------------------------------
+# Test 4: extend parse
+# ---------------------------------------------------------------------------
+
+
+def test_extend_parse_single_clause() -> None:
+    """R extend (Sum(payments, amountPaid) as total) -> ExtendAggregate, one clause."""
+    node = _expr("R extend (Sum(payments, amountPaid) as total)")
+    assert isinstance(node, ExtendAggregate)
+    assert isinstance(node.relation, Identifier)
+    assert node.relation.name == "R"
+    assert len(node.clauses) == 1
+    clause = node.clauses[0]
+    assert clause.agg == Aggregator.SUM
+    assert clause.source_rel == "payments"
+    assert clause.attr == "amountPaid"
+    assert clause.alias == "total"
+
+
+def test_extend_parse_single_arg_clause() -> None:
+    """extend also accepts single-arg clauses (no source_rel)."""
+    node = _expr("R extend (Count(x) as n)")
+    assert isinstance(node, ExtendAggregate)
+    clause = node.clauses[0]
+    assert clause.source_rel is None
+    assert clause.attr == "x"
+    assert clause.alias == "n"
+
+
+def test_extend_no_line_break_after_by_default() -> None:
+    """ExtendAggregate has line_break_after=False by default."""
+    node = _expr("R extend (Count(x) as n)")
+    assert isinstance(node, ExtendAggregate)
+    assert node.line_break_after is False
+
+
+# ---------------------------------------------------------------------------
+# Test 5: extend render
+# ---------------------------------------------------------------------------
+
+
+def test_extend_render_single_clause() -> None:
+    r"""R extend (...) renders with \mathop{\mathrm{Extend}} and correct clause."""
+    result = _expr_latex("R extend (Sum(payments, amountPaid) as total)")
+    expected = (
+        r"R \mathop{\mathrm{Extend}}"
+        r"(\mathrm{Sum}(payments, amountPaid)~\mathrm{as}~total)"
+    )
+    assert expected in result
+
+
+def test_extend_render_mathop_extend() -> None:
+    r"""extend operator emits \mathop{\mathrm{Extend}}."""
+    result = _expr_latex("R extend (Count(x) as n)")
+    assert r"\mathop{\mathrm{Extend}}" in result
+
+
+# ---------------------------------------------------------------------------
+# Test 6: extend multi-clause
+# ---------------------------------------------------------------------------
+
+
+def test_extend_parse_multi_clause() -> None:
+    """R extend (Sum(p, a) as x, Count(p) as y) -> two clauses."""
+    node = _expr("R extend (Sum(p, a) as x, Count(p) as y)")
+    assert isinstance(node, ExtendAggregate)
+    assert len(node.clauses) == 2
+    c0 = node.clauses[0]
+    assert c0.agg == Aggregator.SUM
+    assert c0.source_rel == "p"
+    assert c0.attr == "a"
+    assert c0.alias == "x"
+    c1 = node.clauses[1]
+    assert c1.agg == Aggregator.COUNT
+    assert c1.source_rel is None
+    assert c1.attr == "p"
+    assert c1.alias == "y"
+
+
+def test_extend_render_multi_clause_comma_joined() -> None:
+    r"""Multi-clause extend emits comma-separated clause LaTeX."""
+    result = _expr_latex("R extend (Sum(p, a) as x, Count(p) as y)")
+    assert r"\mathrm{Sum}(p, a)~\mathrm{as}~x" in result
+    assert r"\mathrm{Count}(p)~\mathrm{as}~y" in result
+    joined = r"\mathrm{Sum}(p, a)~\mathrm{as}~x, \mathrm{Count}(p)~\mathrm{as}~y"
+    assert joined in result
+
+
+# ---------------------------------------------------------------------------
+# Test 7: Fuzz routing -- extend abbreviation -> inline math, not zed
+# ---------------------------------------------------------------------------
+
+
+def test_extend_abbreviation_routes_to_inline_math() -> None:
+    r"""X == R extend (...) emits as \noindent $...$, not inside zed."""
+    src = (
+        "TITLE: probe\n\n"
+        "given Foo\n"
+        "schema R\n  x : Foo\nend\n\n"
+        "X == R extend (Sum(p, a) as t)\n"
+    )
+    latex = _doc_latex(src)
+    assert r"\begin{zed}" + "\nX ==" not in latex
+    assert r"\noindent" in latex
+    assert r"$X == R \mathop{\mathrm{Extend}}" in latex
+
+
+# ---------------------------------------------------------------------------
+# Test 8: Regression -- group output unchanged; extend emits no spurious backslash
+# ---------------------------------------------------------------------------
+
+
+def test_group_aggregate_render_regression() -> None:
+    r"""Existing group/Count output unchanged after extend feature is added."""
+    result = _expr_latex("R group (Count(x) as t, Sum(y) as g)")
+    assert r"\mathop{\mathrm{Group}}" in result
+    assert r"\mathrm{Count}(x)~\mathrm{as}~t" in result
+    assert r"\mathrm{Sum}(y)~\mathrm{as}~g" in result
+
+
+def test_extend_single_line_no_spurious_linebreak() -> None:
+    r"""Single-line extend must not inject a line-break into the output."""
+    result = _expr_latex("R extend (Count(x) as n)")
+    assert r"\\" not in result
+
+
+def test_extend_abbreviation_after_extend_no_swallow() -> None:
+    """Abbreviation on the line after extend parses as a separate statement."""
+    src = "E == D extend (Count(a) as ca)\nG == E"
+    doc_result = Parser(_lex(src)).parse()
+    assert isinstance(doc_result, Document)
+    assert len(doc_result.items) == 2
+    assert isinstance(doc_result.items[0], Abbreviation)
+    assert doc_result.items[0].name == "E"
+    assert isinstance(doc_result.items[0].expression, ExtendAggregate)
+    assert isinstance(doc_result.items[1], Abbreviation)
+    assert doc_result.items[1].name == "G"

--- a/tests/test_extend_aggregate.py
+++ b/tests/test_extend_aggregate.py
@@ -283,3 +283,15 @@ def test_extend_abbreviation_after_extend_no_swallow() -> None:
     assert isinstance(doc_result.items[0].expression, ExtendAggregate)
     assert isinstance(doc_result.items[1], Abbreviation)
     assert doc_result.items[1].name == "G"
+
+
+def test_extend_is_legal_as_attribute_name() -> None:
+    r"""`extend` is a reserved keyword but must remain usable as an attribute
+    name (like `group`/`ungroup`), so fields literally named `extend` still
+    parse in projection lists and two-argument aggregates."""
+    # projection attribute list
+    proj = _expr_latex("pi[extend, amount] R")
+    assert "extend" in proj
+    # `extend` as the relation-valued-attribute name in a two-arg aggregate
+    agg = _expr_latex("R extend (Sum(extend, amount) as t)")
+    assert r"\mathrm{Sum}(extend, amount)" in agg


### PR DESCRIPTION
## What

Adds C. J. Date's **`extend`** operator and the **two-argument aggregate** `Agg(rel, attr)` to the relational-algebra family, so a relation-valued attribute (RVA) can be aggregated correctly.

## Why

Projecting to `(key, amount)` then `Sum(amount)` **deduplicates equal values** under set semantics and undercounts — two equal payments on one invoice collapse to one row before the sum. The correct pattern preserves multiplicity:

```
InvPayGrouped == Payment group ({paymentId, amountPaid} as payments)   # nest distinct tuples
PaidPerInv    == InvPayGrouped extend (Sum(payments, amountPaid) as totalInvoicePayment)
```

`group` nests (reduces cardinality); `extend` consumes an RVA and adds a per-tuple scalar (preserves it). That's Date's GROUP vs EXTEND distinction.

## Changes

- **Two-argument aggregate** `Agg(rel, attr)` in the aggregator clause — `Sum(payments, amountPaid)` → `\mathrm{Sum}(payments, amountPaid)`. Second arg is an attribute name. Single-arg form unchanged (distinct arity).
- **`extend` operator** — new keyword; `R extend (Agg(rva, attr) as alias, …)` → `R \mathop{\mathrm{Extend}}(…)`.
- **Fuzz routing** — `ExtendAggregate` added to the DAT expression set, so `extend` renders as inline math and is never routed into a fuzz-checked `zed` block (per the earlier `cross` fuzz-routing fix).

## Notation

Reviewed by **jms**: two-argument aggregate is Date's `SUM(r, exp)` form; rendering `\mathrm{Sum}(payments, amountPaid)~\mathrm{as}~alias` is byte-consistent with the existing single-arg clause. The GROUP-vs-EXTEND choice (option b: add a proper `extend`) is recorded in `docs/DESIGN.md` (ADR). The two-arg form is accepted in any aggregate clause but its correct home is `extend`.

## Tests

`tests/test_extend_aggregate.py` — 20 tests: two-arg parse/render (Sum, Count), single-arg regression (unchanged, `source_rel is None`), `extend` parse/render (single + multi-clause), **inline-routing** (an `extend` abbreviation renders `$…$`, not `\begin{zed}`), and no-spurious-linebreak.

`make check` green (4837 passed, 3 expected xfails). Verified the worked pipeline renders to spec and stays out of fuzz.

## Docs

DESIGN ADR, CHANGELOG (Added), and USER_GUIDE (two-arg form, `extend`, and a `group` vs `extend` comparison with the worked example).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive relational-algebra surface with dedicated tests; single-arg `group` aggregation and existing fuzz routing behavior are unchanged.
> 
> **Overview**
> Adds Date's **`extend`** operator and **`Agg(rel, attr)`** two-argument aggregates so relation-valued attributes from `group ({…} as rva)` can be summed without set-semantics undercounting.
> 
> **Parsing & AST:** New reserved keyword `extend` chains at the same precedence as `group`/`join`/`div`. `AggregatorClause` gains optional `source_rel` when a comma follows the first identifier inside `Count`/`Sum`/etc. New `ExtendAggregate` node holds one relation plus comma-separated aggregator clauses. `extend` remains usable as an attribute name (like `group`).
> 
> **LaTeX:** Two-arg clauses render as `\mathrm{Sum}(payments, amountPaid)~\mathrm{as}~alias`; `extend` renders `R \mathop{\mathrm{Extend}}(...)`. Continuation/line-break behavior for chained `extend` is refactored via `_parse_extend_full` and `_apply_trailing_continuation`.
> 
> **Fuzz routing:** `ExtendAggregate` joins `_DAT_EXPRESSION_TYPES`, so abbreviations with `extend` stay in inline math, not `\begin{zed}`.
> 
> **Tests & docs:** New `tests/test_extend_aggregate.py` (lexer, two-arg/single-arg aggregates, extend parse/render, fuzz routing, regressions). CHANGELOG, DESIGN ADR, and USER_GUIDE document EXTEND vs GROUP and the nest-then-extend pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3176959993348fa62254d85600d834b7e1d8fe3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->