### PR TITLE
docs(design): cite Date 8e Ch.7 in the extend/aggregate ADR

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -3088,8 +3088,9 @@ mislabels it, and the course teaches Date's algebra where the distinction
 is real.  Reviewed by jms (2026-07-01).
 
 **Grounding.**  Confirmed against C. J. Date, *An Introduction to Database
-Systems*, 8e, Ch. 7 (Relational Algebra), pp. 225–229: `EXTEND R ADD (exp
-AS name)` adds a computed attribute; aggregating a relation-valued
+Systems*, 8e, Ch. 7 (Relational Algebra), pp. 225–229:
+`EXTEND R ADD (exp AS name)` adds a computed attribute; aggregating a
+relation-valued
 attribute uses EXTEND (`EXTEND T3 ADD COUNT(Y) AS NP`, where `Y` is
 relation-valued); the two-argument aggregate `SUM(rel, attr)` requires the
 attribute unless the relation is of degree one; and SUMMARIZE (8e:

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -3087,6 +3087,15 @@ EXTEND, not GROUP: GROUP *produces* an RVA and reduces cardinality; EXTEND
 mislabels it, and the course teaches Date's algebra where the distinction
 is real.  Reviewed by jms (2026-07-01).
 
+**Grounding.**  Confirmed against C. J. Date, *An Introduction to Database
+Systems*, 8e, Ch. 7 (Relational Algebra), pp. 225–229: `EXTEND R ADD (exp
+AS name)` adds a computed attribute; aggregating a relation-valued
+attribute uses EXTEND (`EXTEND T3 ADD COUNT(Y) AS NP`, where `Y` is
+relation-valued); the two-argument aggregate `SUM(rel, attr)` requires the
+attribute unless the relation is of degree one; and SUMMARIZE (8e:
+`SUMMARIZE R PER R2{…} ADD …`) is explicitly non-primitive, reducible to
+EXTEND — so EXTEND is the correct primitive to add.
+
 **Consequences.**
 
 - `extend` is a new reserved keyword; relational-algebra documents can now


### PR DESCRIPTION
Grounds the EXTEND + two-argument aggregate ADR (from #70) in C. J. Date, *An Introduction to Database Systems*, 8e, Ch. 7 (pp. 225–229), now searchable via quarry (OCR'd):

- `EXTEND R ADD (exp AS name)` adds a computed attribute (`EXTEND P ADD (WEIGHT * 454 AS GMWT)`).
- Aggregating a relation-valued attribute uses EXTEND: `EXTEND T3 ADD COUNT(Y) AS NP`, where `Y` is relation-valued — exactly the `group ({…} as rva)` then `extend (Sum(rva, attr) …)` pattern.
- The two-argument aggregate `SUM(rel, attr)` requires the attribute unless the relation is degree-one.
- SUMMARIZE (8e: `SUMMARIZE R PER R2{…} ADD …`) is explicitly non-primitive, reducible to EXTEND — so EXTEND was the correct primitive to add.

Docs-only; no code change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edit to an ADR; no runtime or build behavior changes.
> 
> **Overview**
> Adds a **Grounding** subsection to the existing EXTEND / two-argument aggregate ADR in `DESIGN.md`, citing C. J. Date, *An Introduction to Database Systems*, 8e, Ch. 7 (pp. 225–229).
> 
> The new text ties the prior design choices to Date: `EXTEND R ADD (exp AS name)`, EXTEND for aggregating relation-valued attributes (e.g. `EXTEND T3 ADD COUNT(Y) AS NP`), the two-argument `SUM(rel, attr)` form, and the fact that SUMMARIZE is non-primitive and reducible to EXTEND.
> 
> **Docs-only** — no parser, generator, or test changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7516a51460583f0f002224c360f0996af7694b76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->