### PR TITLE
fix(compile): decode subprocess output with errors=replace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`UnicodeDecodeError` when compiling documents with non-UTF-8 output** —
+  `compile.py` ran latexmk/pdflatex/tex-fmt with `text=True` and no
+  `errors=` handler, so a non-UTF-8 byte in the tool's captured output
+  (e.g. `0xa7`/`§` echoed by latexmk) crashed the CLI with an uncaught
+  traceback even though the PDF compiled. All three subprocess calls now
+  pass `errors="replace"`, matching the log-file reads that already used it.
+
 - **Relational-calculus examples used non-Z string literals** —
   `relational_calculus` and `q2d_demo` compared attributes to quoted
   strings (`'Jazz'`, `'Ali'`, `'Centre Court'`), which fuzz rejected with a

--- a/src/txt2tex/compile.py
+++ b/src/txt2tex/compile.py
@@ -31,6 +31,7 @@ def format_tex(tex_path: Path) -> bool:
         [tex_fmt, str(tex_path)],
         capture_output=True,
         text=True,
+        errors="replace",
         check=False,
     )
 
@@ -137,6 +138,7 @@ def _compile_with_latexmk(
         cwd=work_dir,
         capture_output=True,
         text=True,
+        errors="replace",
         check=False,
     )
 
@@ -195,6 +197,7 @@ def _compile_with_pdflatex(
             cwd=work_dir,
             capture_output=True,
             text=True,
+            errors="replace",
             check=False,
         )
 

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -20,7 +20,10 @@ def test_compile_pdf_non_utf8_stdout(tmp_path: Path) -> None:
     # Stub executable: writes a raw latin-1 byte (0xa7, §) and exits 0.
     # This simulates latexmk echoing the source file's non-UTF-8 content.
     stub = tmp_path / "latexmk"
-    stub.write_text("#!/bin/sh\nprintf '\\xa7\\n'\nexit 0\n")
+    # Emit a raw 0xa7 (§, latin-1) byte. Use a POSIX octal escape (\247) —
+    # printf's \xHH hex escape is not portable (dash's printf lacks it),
+    # whereas \ddd octal is required by POSIX and works in every /bin/sh.
+    stub.write_text("#!/bin/sh\nprintf '\\247\\n'\nexit 0\n")
     stub.chmod(stub.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
 
     # Minimal .tex file — content doesn't matter; the stub exits 0.

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -1,0 +1,38 @@
+"""Tests for PDF compilation utilities."""
+
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+from unittest.mock import patch
+
+from txt2tex.compile import compile_pdf
+
+
+def test_compile_pdf_non_utf8_stdout(tmp_path: Path) -> None:
+    """compile_pdf returns True when latexmk emits non-UTF-8 bytes to stdout.
+
+    Before the fix, subprocess.run with text=True decodes stdout as strict
+    UTF-8, raising UnicodeDecodeError on byte 0xa7.  After the fix,
+    errors="replace" is passed so the byte is replaced with the Unicode
+    replacement character and the call succeeds.
+    """
+    # Stub executable: writes a raw latin-1 byte (0xa7, §) and exits 0.
+    # This simulates latexmk echoing the source file's non-UTF-8 content.
+    stub = tmp_path / "latexmk"
+    stub.write_text("#!/bin/sh\nprintf '\\xa7\\n'\nexit 0\n")
+    stub.chmod(stub.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+    # Minimal .tex file — content doesn't matter; the stub exits 0.
+    tex = tmp_path / "doc.tex"
+    tex.write_text("\\documentclass{article}\n\\begin{document}hello\\end{document}\n")
+
+    def fake_which(name: str) -> str | None:
+        return str(stub) if name == "latexmk" else None
+
+    # keep_aux=True skips the cleanup subprocess.run so only the one
+    # text=True call (the main latexmk invocation) is exercised.
+    with patch("txt2tex.compile.shutil.which", side_effect=fake_which):
+        result = compile_pdf(tex, keep_aux=True)
+
+    assert result is True


### PR DESCRIPTION
## Problem

`compile.py` ran `latexmk`, `pdflatex`, and `tex-fmt` with `subprocess.run(..., text=True, ...)` and no `errors=` handler, so their captured output was decoded as strict UTF-8. A non-UTF-8 byte in the output — e.g. `0xa7` (§) that latexmk echoes when a document contains `Z RM §3.9` — raised an **uncaught `UnicodeDecodeError`** and crashed the CLI with a traceback, even though the PDF had already compiled.

Reproduced with `examples/16_multi_decl_calculus/q2d_demo.txt`:
```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa7 in position 6679: invalid start byte
```

## Fix

Add `errors="replace"` to all three `text=True` `subprocess.run` calls (lines 30, 128, 197), so output decodes with replacement characters instead of raising. This matches the `read_text(errors="replace")` guard the log-file readers (`_has_latex_error`, `_show_latex_error`) already use.

## Test

`tests/test_compile.py` stubs `latexmk` with a script that emits a raw `0xa7` byte and exits 0, monkeypatches `shutil.which`, and asserts `compile_pdf` returns `True` instead of raising. Fails with `UnicodeDecodeError` before the fix; passes after. No dependency on a real latexmk — runs in CI.

`make check` green (4856 passed).

## Follow-up (separate issue surfaced, not fixed here)

With the crash gone, building `q2d_demo` now cleanly surfaces a **pre-existing** LaTeX error the crash was masking: its TEXT block writes bare math commands in prose (`` `(\mu ... | (\mu ...))` `` → "Missing $ inserted" at `l.149`). The PDF recovers, but latexmk returns non-zero. That's a q2d_demo authoring bug (needs `$...$` around the math), tracked separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to subprocess text decoding in compile utilities; no auth, data, or compilation logic changes beyond tolerating invalid UTF-8 in captured output.
> 
> **Overview**
> **PDF compile no longer crashes on non-UTF-8 tool output.** `compile.py` used `subprocess.run(..., text=True)` without an `errors` handler for **tex-fmt**, **latexmk**, and **pdflatex**, so bytes like `0xa7` (§) in captured stdout/stderr could raise **`UnicodeDecodeError`** and abort the CLI even when the PDF built. All three calls now pass **`errors="replace"`**, aligned with existing `.log` reads via `read_text(errors="replace")`.
> 
> Adds **`tests/test_compile.py`**: a stub `latexmk` prints a raw `0xa7` byte and exits 0; **`compile_pdf`** is asserted to return **`True`** instead of raising. **CHANGELOG** documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dcb5b4a1708c7e3e3c3cd9dfc42f35c9adabfd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->