### PR TITLE
chore(release): v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-07-04
+
 ### Added
 
 - **`extend` operator and two-argument aggregates** — Date's `EXTEND` for

--- a/src/txt2tex/__version__.py
+++ b/src/txt2tex/__version__.py
@@ -1,3 +1,3 @@
 """Defines the version of the txt2tex package."""
 
-__version__ = "1.6.3"
+__version__ = "2.0.0"


### PR DESCRIPTION
Release **v2.0.0** — version bump + CHANGELOG finalization.

**Major bump** because Phase 2 is a breaking change: `TEXT:` prose no longer auto-detects math (inline math must be wrapped in `$...$`).

## Included since 1.6.3
- **BREAKING** — TEXT prose auto-detection removed; explicit `$...$` whiteboard inline math; bare-symbol mode; strict `$...$`.
- **Security** — `\`/`{`/`}` escaped in TEXT prose (closes #79 injection).
- **Fixed** — `setminus` word form; RA-name → inline math routing; `P`→ℙ in proof examples; field-selection operands; `$`-parity (#80); UnicodeDecodeError on compile.
- **Added** — `extend` operator + two-argument aggregates.

Version-only diff: `src/txt2tex/__version__.py` (1.6.3 → 2.0.0) + `CHANGELOG.md` ([Unreleased] → [2.0.0] 2026-07-04). Wheel built and smoke-tested in isolation; `make check` green. Tag + PyPI publish + GH release follow the merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version string and changelog only; no application logic changes in the diff.
> 
> **Overview**
> Cuts the **2.0.0** release by bumping `src/txt2tex/__version__.py` from **1.6.3** to **2.0.0** and finalizing **CHANGELOG.md**: the former `[Unreleased]` notes are published under **`[2.0.0] - 2026-07-04`**, with an empty `[Unreleased]` section left for future work.
> 
> No runtime or generator behavior changes in this diff—only packaging metadata and release notes. The major version reflects breaking **TEXT:** behavior and other items already documented in the changelog (e.g. explicit `$...$` inline math, security fixes, `extend`/two-arg aggregates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b1c64264eac2c3f3e82116b3c7119e50370fedc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->