### PR TITLE
docs(adr): record RA-taint routing decision from PR #82

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -3161,3 +3161,81 @@ EXTEND — so EXTEND is the correct primitive to add.
   `cross` fuzz-routing fix).
 - The course did not teach `extend`, so its use is a per-document choice;
   single-argument `group` aggregation is unaffected.
+
+## ADR: RA-taint routing — a Z operator referencing an RA-defined name routes to inline math (PR #82)
+
+**Status**: SETTLED 2026-07-03 (merged in PR #82). Reviewed by jms.
+
+### Context
+
+The `GroupAggregate`/#142 ADR routes an abbreviation `Name == <expr>` to
+unboxed inline math when the RHS *is* a relational-algebra node (a member of
+`_DAT_EXPRESSION_TYPES`), and to a fuzz-checked `\begin{zed}` block otherwise.
+That test is on the *node type of the RHS itself*.
+
+It does not cover a **Z-native operator whose operand references an RA-defined
+name**. Consider:
+
+```text
+A == R project {x}        # RA node   -> inline math \mathrm{Project}(...)
+C == A setminus B         # setminus is a Z-native set op -> routed to zed
+```
+
+`setminus` (and `union`, `intersect`, …) are ordinary Z operators, so
+`C == A setminus B` routed to `\begin{zed}`. But `A` and `B` were defined by RA
+abbreviations that render as `\mathrm{...}` inline math — invisible to fuzz's
+type environment. fuzz therefore rejected `A`/`B` as **"not declared"** on a
+document that is otherwise correct. Relational algebra is not fuzz-checkable at
+all (the `\mathrm{Project}` etc. labels are not Z grammar), so a set operation
+built over RA names cannot live in a typechecked block.
+
+### Decision
+
+Extend routing from a node-type test to a **name-taint analysis**:
+
+1. A name is **RA-tainted** if it is defined (via `==` or a horizontal
+   definition) by an expression that itself routes to inline math.
+2. **Any expression that transitively references a tainted name** is routed to
+   unboxed inline math, not a `zed` block — even when the top operator is
+   Z-native (`setminus`, `union`, `\mapsto`, …).
+3. **Fuzz-declared exclusion (the axdef bridge)**: a name declared in an
+   `axdef`/`schema`/horizontal-definition is fuzz-visible and is **not** tainted
+   even if it also appears in RA context. Genuine Z declarations keep their
+   `zed` typechecking.
+4. **Fixpoint**: taint is computed to a fixpoint in a whole-document pre-pass
+   (recursing into `Section`/`Solution`/`Part`/`Zed`, via a field-agnostic
+   nested-value walk), so forward references (`C` used before `A` is defined)
+   and transitive chains (`A → B → C`) are all caught before generation.
+
+**jms ruling (in the loop for this decision): never fabricate a Z declaration
+for an RA name.** RA operators are not Z; inventing a given-set or `axdef` entry
+so fuzz "accepts" them yields a spec that typechecks but means nothing — a green
+check with no content. The honest rendering is unboxed inline math that fuzz
+does not touch.
+
+### Alternatives rejected
+
+1. **Fabricate a Z declaration (given set / `axdef`) for each RA name** so the
+   surrounding `zed` block typechecks. Rejected by jms: it makes fuzz pass a
+   non-Z construct, defeating the purpose of the type check.
+2. **Leave the Z operator in a `zed` block and accept the "not declared"
+   errors.** Rejected: spurious errors on correct documents; the student cannot
+   distinguish a real type error from an RA artifact.
+3. **Single-pass taint collection (no fixpoint).** Rejected during #82 review:
+   misses forward and transitive references.
+
+### Consequences
+
+- A Z set operation over RA-defined names (`C == A setminus B`) renders as
+  unboxed inline math and no longer triggers a fuzz "not declared" error;
+  axdef-bridged names still typecheck in `zed`.
+- Implemented in `codegen/fuzz_routing.py` + `latex_gen.py`:
+  `_collect_declared_and_tainted_names` (fixpoint pre-pass),
+  `_collect_fuzz_declared_names` (axdef/schema/HorizDef exclusion),
+  `_walk_nested_values` (field-agnostic nested-`Expr` traversal),
+  `_iter_items_in_document_order` (Section/Solution/Part/Zed recursion).
+  Commits `de91a42`, `4c19d9c`, `e9f0602`, `3388ab1`, `dea7fe9`, `6ee1698`.
+- Regression coverage: `tests/test_ra_taint_propagation.py` (37 tests).
+- **Known limitation (deferred, issue #83)**: an RA expression written *inside*
+  a hand-authored `zed` block is still emitted in that block and can trip fuzz.
+  The taint pre-pass routes *abbreviations*, not hand-written `zed` bodies.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -3184,7 +3184,7 @@ C == A setminus B         # setminus is a Z-native set op -> routed to zed
 `setminus` (and `union`, `intersect`, …) are ordinary Z operators, so
 `C == A setminus B` routed to `\begin{zed}`. But `A` and `B` were defined by RA
 abbreviations that render as `\mathrm{...}` inline math — invisible to fuzz's
-type environment. fuzz therefore rejected `A`/`B` as **"not declared"** on a
+type environment, so fuzz rejected `A`/`B` as **"not declared"** on a
 document that is otherwise correct. Relational algebra is not fuzz-checkable at
 all (the `\mathrm{Project}` etc. labels are not Z grammar), so a set operation
 built over RA names cannot live in a typechecked block.


### PR DESCRIPTION
## Gap

PR #82 introduced RA-taint routing: a **Z-native set operator** (`setminus`, `union`, …) whose operand **references an RA-defined name** routes to unboxed inline math instead of a fuzz `zed` block. That's a design decision with rejected alternatives and a jms ruling — but no ADR captured it. The existing routing ADRs (`GroupAggregate`/#142, the `cross` fuzz-routing fix) only cover the case where the RHS node *is* an RA type, not the taint-propagation case.

## This PR

Adds an ADR to `docs/DESIGN.md` recording:
- **Context** — why `C == A setminus B` (with `A`, `B` RA-defined) produced spurious fuzz "not declared" errors.
- **Decision** — name-taint analysis (fixpoint pre-pass, axdef-bridge exclusion, Section/Solution/Part/Zed recursion) + the jms ruling: *never fabricate a Z declaration for an RA name*.
- **Rejected alternatives** — fabricate a Z decl (jms: green check that means nothing); leave in zed and accept the errors; single-pass (no fixpoint) taint.
- **Consequences** — implementation map (`fuzz_routing.py`/`latex_gen.py` helpers, commits, 37-test regression file) and the deferred **issue #83** limitation (RA inside a hand-authored `zed` block).

Docs-only. No code change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update to `docs/DESIGN.md`; no code, tests, or build changes.
> 
> **Overview**
> Documents the **RA-taint routing** design that PR #82 landed in codegen, which prior ADRs (`GroupAggregate` / #142, `cross` fuzz routing) did not capture.
> 
> The new ADR explains why **`C == A setminus B`** with RA-defined **`A`**/**`B`** produced spurious fuzz “not declared” errors when routed to `\begin{zed}`, and records the **fixpoint name-taint** rule: definitions that render as inline math taint names transitively, so Z operators over those names also emit as **unboxed inline math**, with **axdef/schema/horizontal-definition** names excluded. It also records **jms’s rejection** of fabricating Z declarations for RA names, the **rejected alternatives**, implementation pointers (`fuzz_routing.py`, `latex_gen.py`, commits, `tests/test_ra_taint_propagation.py`), and the **deferred #83** limitation for RA inside hand-authored `zed` blocks.
> 
> **Docs-only**—no runtime or generator behavior changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa42f70234198945a0cd288c3b6cdb62b5921888. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->