### PR TITLE
chore(release): v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-07-04
+
+### Fixed
+
+- **Reject relational-algebra constructs inside boxed Z environments** (`zed`,
+  `axdef`, `gendef`, `schema`, `syntax`, and horizontal definitions) with an
+  actionable error instead of emitting invalid Z that `fuzz` rejects with an
+  opaque `Syntax error at symbol "{"`. A relational-algebra expression renders
+  as `\mathrm{Join}(…)` etc. — not Z — so it belongs at top level, where it
+  renders as display math; the error names the offending line and directs the
+  user there. Enforced at every site where an expression enters a fuzz-checked
+  box, and presented as a clean `Error:` line by both the CLI and the
+  interactive REPL. Inline math is unaffected — relational algebra written at
+  top level still renders as display math as before. (#83)
+
 ## [2.0.0] - 2026-07-04
 
 ### Added

--- a/src/txt2tex/__version__.py
+++ b/src/txt2tex/__version__.py
@@ -1,3 +1,3 @@
 """Defines the version of the txt2tex package."""
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"


### PR DESCRIPTION
Patch release for the **issue #83** fix (PR #87, merged): reject relational-algebra constructs inside boxed Z environments with an actionable error instead of emitting invalid Z.

## This PR
- Adds the `CHANGELOG.md` entry for the #83 fix (missed in #87) and promotes `[Unreleased]` → `[2.0.1]`.
- Bumps `src/txt2tex/__version__.py` 2.0.0 → 2.0.1.

## Why patch
The only code change since v2.0.0 is the #83 bug fix. It adds *rejection of invalid input* — no new feature, and nothing that previously produced valid output now breaks (the rejected cases already emitted fuzz-invalid Z). Standard bug-fix → patch bump.

After merge: build, isolated wheel test, `twine upload`, tag `v2.0.1`, GitHub release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release bookkeeping only (version string and changelog); no runtime code changes in this diff.
> 
> **Overview**
> **Patch release v2.0.1** — metadata only; the #83 fix shipped in PR #87.
> 
> Bumps `src/txt2tex/__version__.py` from **2.0.0** to **2.0.1** and adds a **`[2.0.1] - 2026-07-04`** section to `CHANGELOG.md` under **Fixed**, documenting rejection of relational-algebra inside boxed Z environments (`zed`, `axdef`, etc.) with a clear error instead of invalid fuzz output. Leaves an empty **`[Unreleased]`** heading for future notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 830dfdb96e3e80503ab31f10a3c60bc21de9157c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->