### PR TITLE
docs: session closeout — process rules, maintenance invariants, complexity refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,10 @@ When delegating implementation work, the specialist's
 - ❌ No defensive coding or fallback logic unless explicitly requested
 - ❌ No `hasattr()` — use protocols instead
 - ❌ No duck typing — use explicit protocol inheritance
+- ❌ No batch/scripted edits to source files (`sed`/`awk`/`perl -i`/Python
+  one-liner substitutions), **even for a pure mechanical rename**. Edit each
+  file by hand with the Edit tool — batch edits have silently corrupted files
+  here. This binds delegated specialists too; state it in their mission.
 
 ## Workflow
 
@@ -302,9 +306,20 @@ Reported problems are almost always real bugs in the code.
 - Never say "intermittent" or "race condition" without proof.
 - When fixing a bug, grep for the same pattern across the entire
   codebase. Fix every instance, not just the reported one.
+- A bug *class* rarely lives in one place. Sweep every render path
+  (`codegen/` **and** `latex_gen.py`) and every entry point (the CLI
+  **and** the REPL) — not just the reported site. This session, one
+  "RA in a boxed Z environment" defect recurred across ~7 render sites
+  and both entry points, and an indentation fix initially missed a
+  second lambda code path. Treat each Cursor/Copilot finding of a
+  missed path as a real instance to fix, not a nit to wave off.
 - For output-facing changes (LaTeX/PDF), read the complete output as
   the consumer sees it and fix every defect in one pass. Do not ship
   symptom-by-symptom fixes.
+- Delegated documentation must **CLI-verify every rendered snippet**
+  (run the input through `txt2tex --tex-only` and paste the actual
+  output) — never hand-author or carry over an unverified LaTeX/output
+  example. A stale snippet slipped through review this session.
 - Match investigation depth to question complexity.
 
 ### Testing
@@ -629,3 +644,10 @@ When starting fresh:
   rationales or making product calls on his behalf.
 - `.tex` files are committed even though they are generated — they are
   first-class assets.
+- `make complexity-report` composes radon/lizard/pydeps into
+  `docs/complexity-report.{md,json}` (committed, so runs show deltas). Not a
+  per-commit gate — run it periodically and after large changes. Two files
+  carry known **pre-existing** high complexity: `lexer.py`
+  (`_scan_token`, `_scan_identifier`) and `parser_pkg/expressions.py`
+  (`_parse_postfix`). Adding to those two warrants extra care; prefer a
+  shared helper over concentrating new branches in them.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -155,6 +155,36 @@ Input Text
 
 **Simplified Example**: For a minimal implementation of this pipeline, see [rpn2tex](https://github.com/jmf-pobox/rpn2tex) — a tutorial project that converts RPN expressions to LaTeX using the same architecture (lexer → parser → AST → generator) with only ~6 token types and 2 AST nodes instead of 100+.
 
+## Maintenance invariants
+
+Cross-cutting rules that new code must preserve. Each is detailed in an ADR
+below; violating one silently re-opens a whole bug class, so they are stated
+here for discoverability.
+
+1. **Relational algebra is never emitted into a fuzz-checked Z box.** RA
+   constructs render as engine-internal `\mathrm{...}` labels that fuzz cannot
+   parse. They route to unboxed inline/display math; a `zed`, `axdef`,
+   `gendef`, `schema`, or `syntax` box that contains one is a user error,
+   rejected via `_reject_ra_in_box` (raises `RaInZedError`; both the CLI and
+   REPL present it cleanly). A horizontal definition (`Name defs RHS`) is itself
+   emitted inside a `zed`, so it passes block kind `"zed"` — it is not a
+   distinct block kind. **Any new site that emits an `Expr` into a boxed Z
+   environment must call `_reject_ra_in_box(...)` with the real block kind** (one
+   of those five), or it re-opens
+   issue #83. See the two RA ADRs ("RA-taint routing", "RA construct inside an
+   explicit `zed` block — hard rejection"). Never fabricate a Z declaration for
+   an RA name to make fuzz "accept" it (jms).
+
+2. **Z-paragraph indentation tracks binding depth.** A continuation line inside
+   a Z paragraph is indented `\t{depth}` where `depth` = the number of binders
+   (`forall`/`exists`/`exists1`/`lambda`/`mu`/set comprehension) enclosing it,
+   via `_binding_depth` + `_get_indentation()`. **Any new binder must increment
+   `_binding_depth` around its scoped body** (predicate and term share one
+   level), or its wrapped body de-nests. See the ADR "Z-paragraph indentation
+   tracks binding depth". `\t{n}` is fuzz's tab macro (defined in fuzz.sty and
+   the zed packages), not `\quad`; `\quad` is only the depth-0 fallback. fuzz's
+   type checker ignores both as layout, so these are reader-facing only.
+
 ## Component Design
 
 ### 1. Lexer (Tokenizer)

--- a/docs/complexity-report.json
+++ b/docs/complexity-report.json
@@ -1,6 +1,6 @@
 {
-  "generated": "2026-05-25T08:52:21+00:00",
-  "commit": "6a31c21",
+  "generated": "2026-07-04T22:04:19+00:00",
+  "commit": "dde0216",
   "src": "src/txt2tex",
   "mi": [
     {
@@ -14,14 +14,9 @@
       "mi": 0.0
     },
     {
-      "file": "src/txt2tex/codegen/text_pipeline.py",
-      "grade": "B",
-      "mi": 11.9
-    },
-    {
       "file": "src/txt2tex/codegen/expressions.py",
       "grade": "A",
-      "mi": 22.11
+      "mi": 20.36
     },
     {
       "file": "src/txt2tex/codegen/proofs.py",
@@ -31,7 +26,12 @@
     {
       "file": "src/txt2tex/ast_nodes.py",
       "grade": "A",
-      "mi": 29.32
+      "mi": 28.81
+    },
+    {
+      "file": "src/txt2tex/latex_gen.py",
+      "grade": "A",
+      "mi": 33.09
     },
     {
       "file": "src/txt2tex/parser.py",
@@ -39,19 +39,14 @@
       "mi": 33.93
     },
     {
-      "file": "src/txt2tex/latex_gen.py",
-      "grade": "A",
-      "mi": 38.89
-    },
-    {
       "file": "src/txt2tex/parser_pkg/text_blocks.py",
       "grade": "A",
-      "mi": 39.6
+      "mi": 39.75
     },
     {
       "file": "src/txt2tex/parser_pkg/paragraphs.py",
       "grade": "A",
-      "mi": 40.65
+      "mi": 40.57
     },
     {
       "file": "src/txt2tex/parser_pkg/proofs.py",
@@ -61,7 +56,7 @@
     {
       "file": "src/txt2tex/codegen/paragraphs.py",
       "grade": "A",
-      "mi": 45.55
+      "mi": 42.78
     },
     {
       "file": "src/txt2tex/parser_pkg/schemas.py",
@@ -71,17 +66,27 @@
     {
       "file": "src/txt2tex/codegen/text_blocks.py",
       "grade": "A",
-      "mi": 47.11
+      "mi": 46.51
     },
     {
       "file": "src/txt2tex/cli.py",
       "grade": "A",
-      "mi": 47.6
+      "mi": 46.6
     },
     {
       "file": "src/txt2tex/parser_pkg/algebra.py",
       "grade": "A",
-      "mi": 51.04
+      "mi": 47.32
+    },
+    {
+      "file": "src/txt2tex/codegen/text_pipeline.py",
+      "grade": "A",
+      "mi": 51.75
+    },
+    {
+      "file": "src/txt2tex/codegen/schemas.py",
+      "grade": "A",
+      "mi": 52.65
     },
     {
       "file": "src/txt2tex/free_vars.py",
@@ -91,22 +96,22 @@
     {
       "file": "src/txt2tex/repl.py",
       "grade": "A",
-      "mi": 56.62
-    },
-    {
-      "file": "src/txt2tex/codegen/schemas.py",
-      "grade": "A",
-      "mi": 57.64
+      "mi": 56.12
     },
     {
       "file": "src/txt2tex/compile.py",
       "grade": "A",
-      "mi": 60.84
+      "mi": 60.7
+    },
+    {
+      "file": "src/txt2tex/codegen/_dispatch.py",
+      "grade": "A",
+      "mi": 66.1
     },
     {
       "file": "src/txt2tex/codegen/paren_policy.py",
       "grade": "A",
-      "mi": 67.1
+      "mi": 67.09
     },
     {
       "file": "src/txt2tex/parser_pkg/lexer_state.py",
@@ -114,14 +119,19 @@
       "mi": 68.07
     },
     {
-      "file": "src/txt2tex/errors.py",
+      "file": "src/txt2tex/codegen/fuzz_routing.py",
       "grade": "A",
-      "mi": 74.27
+      "mi": 70.75
     },
     {
       "file": "src/txt2tex/codegen/algebra.py",
       "grade": "A",
-      "mi": 74.99
+      "mi": 70.92
+    },
+    {
+      "file": "src/txt2tex/errors.py",
+      "grade": "A",
+      "mi": 74.27
     },
     {
       "file": "src/txt2tex/parser_pkg/types.py",
@@ -139,11 +149,6 @@
       "mi": 82.2
     },
     {
-      "file": "src/txt2tex/codegen/fuzz_routing.py",
-      "grade": "A",
-      "mi": 91.61
-    },
-    {
       "file": "src/txt2tex/codegen/bindings.py",
       "grade": "A",
       "mi": 92.32
@@ -152,6 +157,11 @@
       "file": "src/txt2tex/parser_pkg/errors.py",
       "grade": "A",
       "mi": 93.86
+    },
+    {
+      "file": "src/txt2tex/codegen/_toc.py",
+      "grade": "A",
+      "mi": 98.85
     },
     {
       "file": "src/txt2tex/constants.py",
@@ -189,11 +199,6 @@
       "mi": 100.0
     },
     {
-      "file": "src/txt2tex/codegen/_dispatch.py",
-      "grade": "A",
-      "mi": 100.0
-    },
-    {
       "file": "src/txt2tex/codegen/_smoke.py",
       "grade": "A",
       "mi": 100.0
@@ -202,7 +207,7 @@
   "cc": [
     {
       "file": "src/txt2tex/lexer.py",
-      "line": 339,
+      "line": 343,
       "kind": "method",
       "name": "Lexer._scan_token",
       "grade": "F",
@@ -210,7 +215,7 @@
     },
     {
       "file": "src/txt2tex/lexer.py",
-      "line": 1035,
+      "line": 1039,
       "kind": "method",
       "name": "Lexer._scan_identifier",
       "grade": "F",
@@ -218,11 +223,11 @@
     },
     {
       "file": "src/txt2tex/parser_pkg/expressions.py",
-      "line": 2084,
+      "line": 2195,
       "kind": "method",
       "name": "_ExpressionsParser._parse_postfix",
       "grade": "F",
-      "complexity": 43
+      "complexity": 45
     },
     {
       "file": "src/txt2tex/codegen/proofs.py",
@@ -234,17 +239,9 @@
     },
     {
       "file": "src/txt2tex/lexer.py",
-      "line": 226,
+      "line": 230,
       "kind": "class",
       "name": "Lexer",
-      "grade": "E",
-      "complexity": 31
-    },
-    {
-      "file": "src/txt2tex/parser_pkg/expressions.py",
-      "line": 1812,
-      "kind": "method",
-      "name": "_ExpressionsParser._parse_cross",
       "grade": "E",
       "complexity": 31
     },
@@ -266,9 +263,17 @@
     },
     {
       "file": "src/txt2tex/codegen/text_blocks.py",
-      "line": 80,
+      "line": 83,
       "kind": "method",
       "name": "_TextBlocksCodegen._generate_part",
+      "grade": "D",
+      "complexity": 30
+    },
+    {
+      "file": "src/txt2tex/parser_pkg/expressions.py",
+      "line": 1417,
+      "kind": "method",
+      "name": "_ExpressionsParser._parse_set_comprehension_from_brace",
       "grade": "D",
       "complexity": 29
     },
@@ -282,9 +287,17 @@
     },
     {
       "file": "src/txt2tex/latex_gen.py",
-      "line": 543,
+      "line": 715,
       "kind": "method",
       "name": "LaTeXGenerator._has_line_breaks_structural",
+      "grade": "D",
+      "complexity": 28
+    },
+    {
+      "file": "src/txt2tex/parser_pkg/expressions.py",
+      "line": 1871,
+      "kind": "method",
+      "name": "_ExpressionsParser._parse_cross",
       "grade": "D",
       "complexity": 28
     },
@@ -298,7 +311,7 @@
     },
     {
       "file": "src/txt2tex/parser.py",
-      "line": 449,
+      "line": 459,
       "kind": "method",
       "name": "Parser._parse_document_item",
       "grade": "D",
@@ -313,12 +326,20 @@
       "complexity": 25
     },
     {
-      "file": "src/txt2tex/codegen/text_pipeline.py",
-      "line": 697,
+      "file": "src/txt2tex/codegen/schemas.py",
+      "line": 183,
       "kind": "method",
-      "name": "_TextPipelineCodegen._convert_comparison_operators",
+      "name": "_SchemasCodegen._generate_schema",
       "grade": "D",
       "complexity": 25
+    },
+    {
+      "file": "src/txt2tex/cli.py",
+      "line": 163,
+      "kind": "function",
+      "name": "main",
+      "grade": "D",
+      "complexity": 24
     },
     {
       "file": "src/txt2tex/parser_pkg/proofs.py",
@@ -329,40 +350,16 @@
       "complexity": 24
     },
     {
-      "file": "src/txt2tex/parser_pkg/expressions.py",
-      "line": 1396,
-      "kind": "method",
-      "name": "_ExpressionsParser._parse_set_comprehension_from_brace",
-      "grade": "D",
-      "complexity": 23
-    },
-    {
-      "file": "src/txt2tex/codegen/schemas.py",
-      "line": 161,
-      "kind": "method",
-      "name": "_SchemasCodegen._generate_schema",
-      "grade": "D",
-      "complexity": 23
-    },
-    {
       "file": "src/txt2tex/parser.py",
-      "line": 667,
+      "line": 684,
       "kind": "method",
       "name": "Parser._parse_declaration_or_inclusion",
       "grade": "D",
       "complexity": 22
     },
     {
-      "file": "src/txt2tex/cli.py",
-      "line": 161,
-      "kind": "function",
-      "name": "main",
-      "grade": "D",
-      "complexity": 22
-    },
-    {
       "file": "src/txt2tex/latex_gen.py",
-      "line": 374,
+      "line": 544,
       "kind": "method",
       "name": "LaTeXGenerator.generate_document",
       "grade": "D",
@@ -370,7 +367,7 @@
     },
     {
       "file": "src/txt2tex/parser_pkg/expressions.py",
-      "line": 2480,
+      "line": 2671,
       "kind": "method",
       "name": "_ExpressionsParser._parse_atom",
       "grade": "D",
@@ -378,7 +375,7 @@
     },
     {
       "file": "src/txt2tex/codegen/expressions.py",
-      "line": 475,
+      "line": 485,
       "kind": "method",
       "name": "_ExpressionsCodegen._generate_logical_quantifier",
       "grade": "D",
@@ -398,20 +395,20 @@
     {
       "file": "src/txt2tex/lexer.py",
       "function": "_scan_identifier",
-      "nloc": 398,
+      "nloc": 399,
       "ccn": 138,
-      "tokens": 2433,
+      "tokens": 2435,
       "params": 3,
-      "length": 560
+      "length": 561
     },
     {
       "file": "src/txt2tex/parser_pkg/expressions.py",
       "function": "_parse_postfix",
-      "nloc": 190,
-      "ccn": 43,
-      "tokens": 949,
+      "nloc": 232,
+      "ccn": 45,
+      "tokens": 1127,
       "params": 2,
-      "length": 330
+      "length": 410
     },
     {
       "file": "src/txt2tex/codegen/proofs.py",
@@ -424,21 +421,39 @@
     },
     {
       "file": "src/txt2tex/parser_pkg/expressions.py",
-      "function": "_parse_quantifier",
-      "nloc": 169,
-      "ccn": 32,
-      "tokens": 971,
+      "function": "_parse_set_comprehension_from_brace",
+      "nloc": 142,
+      "ccn": 33,
+      "tokens": 827,
       "params": 1,
-      "length": 284
+      "length": 185
+    },
+    {
+      "file": "src/txt2tex/parser_pkg/expressions.py",
+      "function": "_parse_quantifier",
+      "nloc": 170,
+      "ccn": 32,
+      "tokens": 978,
+      "params": 1,
+      "length": 286
     },
     {
       "file": "src/txt2tex/parser_pkg/expressions.py",
       "function": "_parse_cross",
-      "nloc": 162,
-      "ccn": 32,
-      "tokens": 858,
+      "nloc": 156,
+      "ccn": 30,
+      "tokens": 821,
       "params": 1,
-      "length": 196
+      "length": 197
+    },
+    {
+      "file": "src/txt2tex/codegen/text_blocks.py",
+      "function": "_generate_part",
+      "nloc": 135,
+      "ccn": 30,
+      "tokens": 905,
+      "params": 2,
+      "length": 190
     },
     {
       "file": "src/txt2tex/parser_pkg/paragraphs.py",
@@ -448,15 +463,6 @@
       "tokens": 575,
       "params": 1,
       "length": 154
-    },
-    {
-      "file": "src/txt2tex/codegen/text_blocks.py",
-      "function": "_generate_part",
-      "nloc": 133,
-      "ccn": 29,
-      "tokens": 895,
-      "params": 2,
-      "length": 188
     },
     {
       "file": "src/txt2tex/codegen/proofs.py",
@@ -479,29 +485,29 @@
     {
       "file": "src/txt2tex/parser.py",
       "function": "parse",
-      "nloc": 170,
+      "nloc": 176,
       "ccn": 26,
-      "tokens": 875,
+      "tokens": 892,
       "params": 1,
-      "length": 223
+      "length": 233
     },
     {
-      "file": "src/txt2tex/parser_pkg/expressions.py",
-      "function": "_parse_set_comprehension_from_brace",
-      "nloc": 106,
+      "file": "src/txt2tex/codegen/schemas.py",
+      "function": "_generate_schema",
+      "nloc": 121,
       "ccn": 26,
-      "tokens": 636,
-      "params": 1,
-      "length": 147
+      "tokens": 709,
+      "params": 2,
+      "length": 164
     },
     {
       "file": "src/txt2tex/parser.py",
       "function": "_parse_document_item",
-      "nloc": 52,
+      "nloc": 58,
       "ccn": 26,
-      "tokens": 420,
+      "tokens": 437,
       "params": 1,
-      "length": 61
+      "length": 67
     },
     {
       "file": "src/txt2tex/free_vars.py",
@@ -513,22 +519,13 @@
       "length": 87
     },
     {
-      "file": "src/txt2tex/codegen/text_pipeline.py",
-      "function": "_convert_comparison_operators",
-      "nloc": 49,
-      "ccn": 25,
-      "tokens": 348,
-      "params": 2,
-      "length": 69
-    },
-    {
-      "file": "src/txt2tex/codegen/schemas.py",
-      "function": "_generate_schema",
-      "nloc": 91,
+      "file": "src/txt2tex/cli.py",
+      "function": "main",
+      "nloc": 166,
       "ccn": 24,
-      "tokens": 525,
-      "params": 2,
-      "length": 142
+      "tokens": 740,
+      "params": 0,
+      "length": 193
     },
     {
       "file": "src/txt2tex/parser_pkg/proofs.py",
@@ -538,15 +535,6 @@
       "tokens": 531,
       "params": 3,
       "length": 116
-    },
-    {
-      "file": "src/txt2tex/cli.py",
-      "function": "main",
-      "nloc": 159,
-      "ccn": 22,
-      "tokens": 702,
-      "params": 0,
-      "length": 186
     },
     {
       "file": "src/txt2tex/parser_pkg/expressions.py",
@@ -578,20 +566,20 @@
     {
       "file": "src/txt2tex/latex_gen.py",
       "function": "generate_document",
-      "nloc": 66,
+      "nloc": 68,
       "ccn": 22,
-      "tokens": 508,
+      "tokens": 523,
       "params": 2,
-      "length": 117
+      "length": 119
     },
     {
       "file": "src/txt2tex/parser_pkg/expressions.py",
       "function": "_parse_quantifier_continuation",
-      "nloc": 100,
+      "nloc": 103,
       "ccn": 20,
-      "tokens": 584,
+      "tokens": 593,
       "params": 5,
-      "length": 148
+      "length": 152
     },
     {
       "file": "src/txt2tex/codegen/expressions.py",
@@ -640,11 +628,11 @@
     {
       "module": "txt2tex.cli",
       "fan_in": 1,
-      "fan_out": 8
+      "fan_out": 11
     },
     {
       "module": "txt2tex.codegen",
-      "fan_in": 16,
+      "fan_in": 18,
       "fan_out": 15
     },
     {
@@ -656,6 +644,11 @@
       "module": "txt2tex.codegen._smoke",
       "fan_in": 3,
       "fan_out": 3
+    },
+    {
+      "module": "txt2tex.codegen._toc",
+      "fan_in": 2,
+      "fan_out": 0
     },
     {
       "module": "txt2tex.codegen.algebra",
@@ -684,7 +677,7 @@
     },
     {
       "module": "txt2tex.codegen.paragraphs",
-      "fan_in": 3,
+      "fan_in": 5,
       "fan_out": 4
     },
     {
@@ -709,8 +702,8 @@
     },
     {
       "module": "txt2tex.codegen.text_pipeline",
-      "fan_in": 3,
-      "fan_out": 7
+      "fan_in": 5,
+      "fan_out": 6
     },
     {
       "module": "txt2tex.codegen.types",
@@ -724,7 +717,7 @@
     },
     {
       "module": "txt2tex.constants",
-      "fan_in": 3,
+      "fan_in": 2,
       "fan_out": 0
     },
     {
@@ -740,7 +733,7 @@
     {
       "module": "txt2tex.latex_gen",
       "fan_in": 3,
-      "fan_out": 18
+      "fan_out": 19
     },
     {
       "module": "txt2tex.lexer",
@@ -810,7 +803,7 @@
     {
       "module": "txt2tex.repl",
       "fan_in": 2,
-      "fan_out": 7
+      "fan_out": 10
     },
     {
       "module": "txt2tex.tokens",
@@ -864,13 +857,13 @@
       },
       {
         "commit": "11773d3",
-        "date": "2026-05-19",
+        "date": "2026-05-18",
         "loc": 1314,
         "cc": 73
       },
       {
         "commit": "c62874b",
-        "date": "2026-05-19",
+        "date": "2026-05-18",
         "loc": 1230,
         "cc": 69
       }
@@ -878,7 +871,7 @@
     "src/txt2tex/cli.py": [
       {
         "commit": "c62874b",
-        "date": "2026-05-19",
+        "date": "2026-05-18",
         "loc": 344,
         "cc": 38
       }
@@ -886,7 +879,7 @@
     "src/txt2tex/compile.py": [
       {
         "commit": "c62874b",
-        "date": "2026-05-19",
+        "date": "2026-05-18",
         "loc": 248,
         "cc": 33
       }
@@ -894,7 +887,7 @@
     "src/txt2tex/constants.py": [
       {
         "commit": "c62874b",
-        "date": "2026-05-19",
+        "date": "2026-05-18",
         "loc": 72,
         "cc": 0
       }
@@ -902,7 +895,7 @@
     "src/txt2tex/errors.py": [
       {
         "commit": "c62874b",
-        "date": "2026-05-19",
+        "date": "2026-05-18",
         "loc": 136,
         "cc": 13
       }
@@ -954,7 +947,7 @@
       },
       {
         "commit": "9ca24d2",
-        "date": "2026-05-21",
+        "date": "2026-05-20",
         "loc": 6100,
         "cc": 825
       },
@@ -1088,13 +1081,13 @@
       },
       {
         "commit": "11773d3",
-        "date": "2026-05-19",
+        "date": "2026-05-18",
         "loc": 1460,
         "cc": 350
       },
       {
         "commit": "c62874b",
-        "date": "2026-05-19",
+        "date": "2026-05-18",
         "loc": 1441,
         "cc": 346
       }
@@ -1126,7 +1119,7 @@
       },
       {
         "commit": "9ca24d2",
-        "date": "2026-05-21",
+        "date": "2026-05-20",
         "loc": 5849,
         "cc": 851
       },
@@ -1174,13 +1167,13 @@
       },
       {
         "commit": "11773d3",
-        "date": "2026-05-19",
+        "date": "2026-05-18",
         "loc": 5577,
         "cc": 809
       },
       {
         "commit": "c62874b",
-        "date": "2026-05-19",
+        "date": "2026-05-18",
         "loc": 5425,
         "cc": 794
       }
@@ -1194,7 +1187,7 @@
       },
       {
         "commit": "c62874b",
-        "date": "2026-05-19",
+        "date": "2026-05-18",
         "loc": 321,
         "cc": 38
       }
@@ -1232,13 +1225,13 @@
       },
       {
         "commit": "11773d3",
-        "date": "2026-05-19",
+        "date": "2026-05-18",
         "loc": 227,
         "cc": 4
       },
       {
         "commit": "c62874b",
-        "date": "2026-05-19",
+        "date": "2026-05-18",
         "loc": 222,
         "cc": 4
       }

--- a/docs/complexity-report.md
+++ b/docs/complexity-report.md
@@ -1,6 +1,6 @@
 # Complexity Report
 
-_Generated 2026-05-25T08:52:21+00:00 at commit `6a31c21`._
+_Generated 2026-07-04T22:04:19+00:00 at commit `dde0216`._
 
 This snapshot is produced by `make complexity-report` (see `scripts/complexity_report.py`).  It composes radon, lizard, pydeps, and wily into a point-in-time view of the codebase plus a trend window if a wily history exists.
 
@@ -12,34 +12,36 @@ Lower = harder to maintain.  Grades: A >= 20, B 10-19, C < 10.
 |------|---:|:-----:|
 | `src/txt2tex/lexer.py` | 0.00 | C |
 | `src/txt2tex/parser_pkg/expressions.py` | 0.00 | C |
-| `src/txt2tex/codegen/text_pipeline.py` | 11.90 | B |
-| `src/txt2tex/codegen/expressions.py` | 22.11 | A |
+| `src/txt2tex/codegen/expressions.py` | 20.36 | A |
 | `src/txt2tex/codegen/proofs.py` | 27.89 | A |
-| `src/txt2tex/ast_nodes.py` | 29.32 | A |
+| `src/txt2tex/ast_nodes.py` | 28.81 | A |
+| `src/txt2tex/latex_gen.py` | 33.09 | A |
 | `src/txt2tex/parser.py` | 33.93 | A |
-| `src/txt2tex/latex_gen.py` | 38.89 | A |
-| `src/txt2tex/parser_pkg/text_blocks.py` | 39.60 | A |
-| `src/txt2tex/parser_pkg/paragraphs.py` | 40.65 | A |
+| `src/txt2tex/parser_pkg/text_blocks.py` | 39.75 | A |
+| `src/txt2tex/parser_pkg/paragraphs.py` | 40.57 | A |
 | `src/txt2tex/parser_pkg/proofs.py` | 41.92 | A |
-| `src/txt2tex/codegen/paragraphs.py` | 45.55 | A |
+| `src/txt2tex/codegen/paragraphs.py` | 42.78 | A |
 | `src/txt2tex/parser_pkg/schemas.py` | 45.91 | A |
-| `src/txt2tex/codegen/text_blocks.py` | 47.11 | A |
-| `src/txt2tex/cli.py` | 47.60 | A |
-| `src/txt2tex/parser_pkg/algebra.py` | 51.04 | A |
+| `src/txt2tex/codegen/text_blocks.py` | 46.51 | A |
+| `src/txt2tex/cli.py` | 46.60 | A |
+| `src/txt2tex/parser_pkg/algebra.py` | 47.32 | A |
+| `src/txt2tex/codegen/text_pipeline.py` | 51.75 | A |
+| `src/txt2tex/codegen/schemas.py` | 52.65 | A |
 | `src/txt2tex/free_vars.py` | 54.21 | A |
-| `src/txt2tex/repl.py` | 56.62 | A |
-| `src/txt2tex/codegen/schemas.py` | 57.64 | A |
-| `src/txt2tex/compile.py` | 60.84 | A |
-| `src/txt2tex/codegen/paren_policy.py` | 67.10 | A |
+| `src/txt2tex/repl.py` | 56.12 | A |
+| `src/txt2tex/compile.py` | 60.70 | A |
+| `src/txt2tex/codegen/_dispatch.py` | 66.10 | A |
+| `src/txt2tex/codegen/paren_policy.py` | 67.09 | A |
 | `src/txt2tex/parser_pkg/lexer_state.py` | 68.07 | A |
+| `src/txt2tex/codegen/fuzz_routing.py` | 70.75 | A |
+| `src/txt2tex/codegen/algebra.py` | 70.92 | A |
 | `src/txt2tex/errors.py` | 74.27 | A |
-| `src/txt2tex/codegen/algebra.py` | 74.99 | A |
 | `src/txt2tex/parser_pkg/types.py` | 77.76 | A |
 | `src/txt2tex/codegen/overflow.py` | 78.70 | A |
 | `src/txt2tex/codegen/types.py` | 82.20 | A |
-| `src/txt2tex/codegen/fuzz_routing.py` | 91.61 | A |
 | `src/txt2tex/codegen/bindings.py` | 92.32 | A |
 | `src/txt2tex/parser_pkg/errors.py` | 93.86 | A |
+| `src/txt2tex/codegen/_toc.py` | 98.85 | A |
 | `src/txt2tex/constants.py` | 100.00 | A |
 | `src/txt2tex/__init__.py` | 100.00 | A |
 | `src/txt2tex/__version__.py` | 100.00 | A |
@@ -47,7 +49,6 @@ Lower = harder to maintain.  Grades: A >= 20, B 10-19, C < 10.
 | `src/txt2tex/parser_pkg/_base.py` | 100.00 | A |
 | `src/txt2tex/parser_pkg/__init__.py` | 100.00 | A |
 | `src/txt2tex/codegen/__init__.py` | 100.00 | A |
-| `src/txt2tex/codegen/_dispatch.py` | 100.00 | A |
 | `src/txt2tex/codegen/_smoke.py` | 100.00 | A |
 
 ## Cyclomatic Complexity ≥ D (radon cc)
@@ -56,58 +57,57 @@ Functions / methods with cyclomatic complexity grade D or worse.
 
 | File | Line | Name | CC | Grade |
 |------|-----:|------|---:|:-----:|
-| `src/txt2tex/lexer.py` | 339 | `Lexer._scan_token` | 192 | F |
-| `src/txt2tex/lexer.py` | 1035 | `Lexer._scan_identifier` | 138 | F |
-| `src/txt2tex/parser_pkg/expressions.py` | 2084 | `_ExpressionsParser._parse_postfix` | 43 | F |
+| `src/txt2tex/lexer.py` | 343 | `Lexer._scan_token` | 192 | F |
+| `src/txt2tex/lexer.py` | 1039 | `Lexer._scan_identifier` | 138 | F |
+| `src/txt2tex/parser_pkg/expressions.py` | 2195 | `_ExpressionsParser._parse_postfix` | 45 | F |
 | `src/txt2tex/codegen/proofs.py` | 308 | `_ProofsCodegen._generate_proof_node_infer` | 37 | E |
-| `src/txt2tex/lexer.py` | 226 | `Lexer` | 31 | E |
-| `src/txt2tex/parser_pkg/expressions.py` | 1812 | `_ExpressionsParser._parse_cross` | 31 | E |
+| `src/txt2tex/lexer.py` | 230 | `Lexer` | 31 | E |
 | `src/txt2tex/parser_pkg/paragraphs.py` | 184 | `_ParagraphsParser._parse_syntax_block` | 30 | D |
 | `src/txt2tex/parser_pkg/expressions.py` | 607 | `_ExpressionsParser._parse_quantifier` | 30 | D |
-| `src/txt2tex/codegen/text_blocks.py` | 80 | `_TextBlocksCodegen._generate_part` | 29 | D |
+| `src/txt2tex/codegen/text_blocks.py` | 83 | `_TextBlocksCodegen._generate_part` | 30 | D |
+| `src/txt2tex/parser_pkg/expressions.py` | 1417 | `_ExpressionsParser._parse_set_comprehension_from_brace` | 29 | D |
 | `src/txt2tex/codegen/proofs.py` | 563 | `_ProofsCodegen._generate_complex_assumption_scope` | 29 | D |
-| `src/txt2tex/latex_gen.py` | 543 | `LaTeXGenerator._has_line_breaks_structural` | 28 | D |
+| `src/txt2tex/latex_gen.py` | 715 | `LaTeXGenerator._has_line_breaks_structural` | 28 | D |
+| `src/txt2tex/parser_pkg/expressions.py` | 1871 | `_ExpressionsParser._parse_cross` | 28 | D |
 | `src/txt2tex/parser.py` | 143 | `Parser.parse` | 26 | D |
-| `src/txt2tex/parser.py` | 449 | `Parser._parse_document_item` | 26 | D |
+| `src/txt2tex/parser.py` | 459 | `Parser._parse_document_item` | 26 | D |
 | `src/txt2tex/free_vars.py` | 134 | `expr_free_vars` | 25 | D |
-| `src/txt2tex/codegen/text_pipeline.py` | 697 | `_TextPipelineCodegen._convert_comparison_operators` | 25 | D |
+| `src/txt2tex/codegen/schemas.py` | 183 | `_SchemasCodegen._generate_schema` | 25 | D |
+| `src/txt2tex/cli.py` | 163 | `main` | 24 | D |
 | `src/txt2tex/parser_pkg/proofs.py` | 342 | `_ProofsParser._parse_proof_node` | 24 | D |
-| `src/txt2tex/parser_pkg/expressions.py` | 1396 | `_ExpressionsParser._parse_set_comprehension_from_brace` | 23 | D |
-| `src/txt2tex/codegen/schemas.py` | 161 | `_SchemasCodegen._generate_schema` | 23 | D |
-| `src/txt2tex/parser.py` | 667 | `Parser._parse_declaration_or_inclusion` | 22 | D |
-| `src/txt2tex/cli.py` | 161 | `main` | 22 | D |
-| `src/txt2tex/latex_gen.py` | 374 | `LaTeXGenerator.generate_document` | 22 | D |
-| `src/txt2tex/parser_pkg/expressions.py` | 2480 | `_ExpressionsParser._parse_atom` | 22 | D |
-| `src/txt2tex/codegen/expressions.py` | 475 | `_ExpressionsCodegen._generate_logical_quantifier` | 22 | D |
+| `src/txt2tex/parser.py` | 684 | `Parser._parse_declaration_or_inclusion` | 22 | D |
+| `src/txt2tex/latex_gen.py` | 544 | `LaTeXGenerator.generate_document` | 22 | D |
+| `src/txt2tex/parser_pkg/expressions.py` | 2671 | `_ExpressionsParser._parse_atom` | 22 | D |
+| `src/txt2tex/codegen/expressions.py` | 485 | `_ExpressionsCodegen._generate_logical_quantifier` | 22 | D |
 
 ## Lizard Warnings (CCN ≥ 20 or NLOC ≥ 100)
 
-_26 function(s) exceed thresholds._
+_25 function(s) exceed thresholds._
 
 | File | Function | CCN | NLOC | Tokens | Params |
 |------|----------|----:|-----:|-------:|-------:|
 | `src/txt2tex/lexer.py` | `_scan_token` | 192 | 438 | 3373 | 1 |
-| `src/txt2tex/lexer.py` | `_scan_identifier` | 138 | 398 | 2433 | 3 |
-| `src/txt2tex/parser_pkg/expressions.py` | `_parse_postfix` | 43 | 190 | 949 | 2 |
+| `src/txt2tex/lexer.py` | `_scan_identifier` | 138 | 399 | 2435 | 3 |
+| `src/txt2tex/parser_pkg/expressions.py` | `_parse_postfix` | 45 | 232 | 1127 | 2 |
 | `src/txt2tex/codegen/proofs.py` | `_generate_proof_node_infer` | 37 | 100 | 616 | 2 |
-| `src/txt2tex/parser_pkg/expressions.py` | `_parse_quantifier` | 32 | 169 | 971 | 1 |
-| `src/txt2tex/parser_pkg/expressions.py` | `_parse_cross` | 32 | 162 | 858 | 1 |
+| `src/txt2tex/parser_pkg/expressions.py` | `_parse_set_comprehension_from_brace` | 33 | 142 | 827 | 1 |
+| `src/txt2tex/parser_pkg/expressions.py` | `_parse_quantifier` | 32 | 170 | 978 | 1 |
+| `src/txt2tex/parser_pkg/expressions.py` | `_parse_cross` | 30 | 156 | 821 | 1 |
+| `src/txt2tex/codegen/text_blocks.py` | `_generate_part` | 30 | 135 | 905 | 2 |
 | `src/txt2tex/parser_pkg/paragraphs.py` | `_parse_syntax_block` | 30 | 96 | 575 | 1 |
-| `src/txt2tex/codegen/text_blocks.py` | `_generate_part` | 29 | 133 | 895 | 2 |
 | `src/txt2tex/codegen/proofs.py` | `_generate_complex_assumption_scope` | 29 | 107 | 572 | 3 |
 | `src/txt2tex/latex_gen.py` | `_has_line_breaks_structural` | 28 | 40 | 343 | 2 |
-| `src/txt2tex/parser.py` | `parse` | 26 | 170 | 875 | 1 |
-| `src/txt2tex/parser_pkg/expressions.py` | `_parse_set_comprehension_from_brace` | 26 | 106 | 636 | 1 |
-| `src/txt2tex/parser.py` | `_parse_document_item` | 26 | 52 | 420 | 1 |
+| `src/txt2tex/parser.py` | `parse` | 26 | 176 | 892 | 1 |
+| `src/txt2tex/codegen/schemas.py` | `_generate_schema` | 26 | 121 | 709 | 2 |
+| `src/txt2tex/parser.py` | `_parse_document_item` | 26 | 58 | 437 | 1 |
 | `src/txt2tex/free_vars.py` | `expr_free_vars` | 25 | 67 | 529 | 1 |
-| `src/txt2tex/codegen/text_pipeline.py` | `_convert_comparison_operators` | 25 | 49 | 348 | 2 |
-| `src/txt2tex/codegen/schemas.py` | `_generate_schema` | 24 | 91 | 525 | 2 |
+| `src/txt2tex/cli.py` | `main` | 24 | 166 | 740 | 0 |
 | `src/txt2tex/parser_pkg/proofs.py` | `_parse_proof_node` | 24 | 84 | 531 | 3 |
-| `src/txt2tex/cli.py` | `main` | 22 | 159 | 702 | 0 |
 | `src/txt2tex/parser_pkg/expressions.py` | `_parse_atom` | 22 | 130 | 709 | 1 |
 | `src/txt2tex/parser.py` | `_parse_declaration_or_inclusion` | 22 | 120 | 644 | 1 |
+| `src/txt2tex/codegen/expressions.py` | `_generate_logical_quantifier` | 22 | 72 | 451 | 3 |
 
-_…6 more not shown._
+_…5 more not shown._
 
 ## Module Structure (pydeps)
 
@@ -116,27 +116,28 @@ _…6 more not shown._
 | `txt2tex` | 34 | 2 |
 | `txt2tex.__version__` | 4 | 0 |
 | `txt2tex.ast_nodes` | 25 | 0 |
-| `txt2tex.cli` | 1 | 8 |
-| `txt2tex.codegen` | 16 | 15 |
+| `txt2tex.cli` | 1 | 11 |
+| `txt2tex.codegen` | 18 | 15 |
 | `txt2tex.codegen._dispatch` | 15 | 2 |
 | `txt2tex.codegen._smoke` | 3 | 3 |
+| `txt2tex.codegen._toc` | 2 | 0 |
 | `txt2tex.codegen.algebra` | 3 | 4 |
 | `txt2tex.codegen.bindings` | 3 | 4 |
 | `txt2tex.codegen.expressions` | 3 | 5 |
 | `txt2tex.codegen.fuzz_routing` | 3 | 4 |
 | `txt2tex.codegen.overflow` | 3 | 3 |
-| `txt2tex.codegen.paragraphs` | 3 | 4 |
+| `txt2tex.codegen.paragraphs` | 5 | 4 |
 | `txt2tex.codegen.paren_policy` | 3 | 4 |
 | `txt2tex.codegen.proofs` | 3 | 4 |
 | `txt2tex.codegen.schemas` | 3 | 4 |
 | `txt2tex.codegen.text_blocks` | 3 | 4 |
-| `txt2tex.codegen.text_pipeline` | 3 | 7 |
+| `txt2tex.codegen.text_pipeline` | 5 | 6 |
 | `txt2tex.codegen.types` | 3 | 4 |
 | `txt2tex.compile` | 3 | 0 |
-| `txt2tex.constants` | 3 | 0 |
+| `txt2tex.constants` | 2 | 0 |
 | `txt2tex.errors` | 3 | 0 |
 | `txt2tex.free_vars` | 2 | 2 |
-| `txt2tex.latex_gen` | 3 | 18 |
+| `txt2tex.latex_gen` | 3 | 19 |
 | `txt2tex.lexer` | 4 | 2 |
 | `txt2tex.parser` | 4 | 14 |
 | `txt2tex.parser_pkg` | 12 | 11 |
@@ -150,7 +151,7 @@ _…6 more not shown._
 | `txt2tex.parser_pkg.schemas` | 3 | 5 |
 | `txt2tex.parser_pkg.text_blocks` | 3 | 5 |
 | `txt2tex.parser_pkg.types` | 3 | 5 |
-| `txt2tex.repl` | 2 | 7 |
+| `txt2tex.repl` | 2 | 10 |
 | `txt2tex.tokens` | 13 | 0 |
 
 ## Recent Trend (wily)
@@ -160,24 +161,33 @@ LoC and cyclomatic complexity at the **oldest** and **newest** revisions in the 
 | File | Oldest commit | Oldest LoC | Oldest CC | Newest commit | Newest LoC | Newest CC | LoC d | CC d |
 |------|--------------|-----------:|----------:|---------------|-----------:|----------:|------:|-----:|
 | `src/txt2tex/latex_gen.py` | `0606052` (2026-05-19) | 5802 | 771 | `3b80a19` (2026-05-22) | 6815 | 868 | +1013 | +97 |
-| `src/txt2tex/parser.py` | `c62874b` (2026-05-19) | 5425 | 794 | `17e0be0` (2026-05-22) | 6280 | 912 | +855 | +118 |
-| `src/txt2tex/ast_nodes.py` | `c62874b` (2026-05-19) | 1230 | 69 | `3b80a19` (2026-05-22) | 1427 | 80 | +197 | +11 |
-| `src/txt2tex/lexer.py` | `c62874b` (2026-05-19) | 1441 | 346 | `772861d` (2026-05-22) | 1635 | 394 | +194 | +48 |
-| `src/txt2tex/tokens.py` | `c62874b` (2026-05-19) | 222 | 4 | `3b80a19` (2026-05-22) | 239 | 4 | +17 | +0 |
+| `src/txt2tex/parser.py` | `c62874b` (2026-05-18) | 5425 | 794 | `17e0be0` (2026-05-22) | 6280 | 912 | +855 | +118 |
+| `src/txt2tex/ast_nodes.py` | `c62874b` (2026-05-18) | 1230 | 69 | `3b80a19` (2026-05-22) | 1427 | 80 | +197 | +11 |
+| `src/txt2tex/lexer.py` | `c62874b` (2026-05-18) | 1441 | 346 | `772861d` (2026-05-22) | 1635 | 394 | +194 | +48 |
+| `src/txt2tex/tokens.py` | `c62874b` (2026-05-18) | 222 | 4 | `3b80a19` (2026-05-22) | 239 | 4 | +17 | +0 |
 | `src/txt2tex/free_vars.py` | `92823b7` (2026-05-20) | 212 | 42 | `17e0be0` (2026-05-22) | 214 | 41 | +2 | -1 |
 
 ## Delta vs Prior Snapshot
 
-Prior snapshot: 2026-05-23T09:54:44+00:00 @ `5ef7054`
+Prior snapshot: 2026-05-25T08:52:21+00:00 @ `6a31c21`
 
 **MI shifts (Δ ≥ 0.5):**
-  src/txt2tex/ast_nodes.py: MI 30.57 -> 29.32 (↓1.25)
-  src/txt2tex/parser.py: MI 0.00 -> 33.93 (↑33.93)
-  src/txt2tex/latex_gen.py: MI 0.00 -> 38.89 (↑38.89)
-  src/txt2tex/free_vars.py: MI 53.22 -> 54.21 (↑0.99)
+  src/txt2tex/codegen/expressions.py: MI 22.11 -> 20.36 (↓1.75)
+  src/txt2tex/ast_nodes.py: MI 29.32 -> 28.81 (↓0.51)
+  src/txt2tex/latex_gen.py: MI 38.89 -> 33.09 (↓5.80)
+  src/txt2tex/codegen/paragraphs.py: MI 45.55 -> 42.78 (↓2.77)
+  src/txt2tex/codegen/text_blocks.py: MI 47.11 -> 46.51 (↓0.60)
+  src/txt2tex/cli.py: MI 47.60 -> 46.60 (↓1.00)
+  src/txt2tex/parser_pkg/algebra.py: MI 51.04 -> 47.32 (↓3.72)
+  src/txt2tex/codegen/text_pipeline.py: MI 11.90 -> 51.75 (↑39.85)
+  src/txt2tex/codegen/schemas.py: MI 57.64 -> 52.65 (↓4.99)
+  src/txt2tex/repl.py: MI 56.62 -> 56.12 (↓0.50)
+  src/txt2tex/codegen/_dispatch.py: MI 100.00 -> 66.10 (↓33.90)
+  src/txt2tex/codegen/fuzz_routing.py: MI 91.61 -> 70.75 (↓20.86)
+  src/txt2tex/codegen/algebra.py: MI 74.99 -> 70.92 (↓4.07)
 
-  D-or-worse functions: 23 → 23
-  Lizard warnings: 26 → 26
+  D-or-worse functions: 23 → 22
+  Lizard warnings: 26 → 25
 
 ---
 


### PR DESCRIPTION
Session closeout capturing what wasn't yet written down.

## CLAUDE.md
- **No batch/scripted source edits** (even a mechanical rename) — edit per file by hand; batch edits have corrupted files here. Now binds delegated specialists. (A rename via a one-liner slipped this rule this session.)
- **Debugging**: a bug *class* spans render paths (`codegen/` **and** `latex_gen.py`) and entry points (CLI **and** REPL) — sweep all, not just the reported site. Delegated docs must **CLI-verify every rendered snippet**. (Both were slips caught by the bot review loop this session.)
- Standing reminder for `make complexity-report` and the two **pre-existing** high-complexity files (`lexer.py`, `parser_pkg/expressions.py`).

## docs/DESIGN.md
- New **"Maintenance invariants"** section (near the top, ahead of the ADRs) consolidating the two cross-cutting rules this session established:
  1. **RA is never emitted into a fuzz box** — any new box-render site must call `_reject_ra_in_box`.
  2. **Z-paragraph indentation tracks binding depth** — any new binder must increment `_binding_depth`.

## docs/complexity-report.{md,json}
- Refreshed snapshot at `dde0216` (prior committed one was 2026-05-25). Net complexity roughly flat this session (D-functions 23→22); this session's guards lowered MI in the codegen files they touched, all still grade A.

Docs-only.

_Note: `make complexity-report` also drops an untracked `txt2tex.svg` (pydeps byproduct) — not committed here; may warrant a `.gitignore` entry in a follow-up._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and committed metrics only; no runtime or LaTeX emission behavior changes in this diff.
> 
> **Overview**
> **Docs-only** session closeout: agent workflow rules, discoverable maintenance invariants, and an updated complexity snapshot.
> 
> **`CLAUDE.md`** adds standing rules from recent review loops: forbid batch/scripted source edits (even renames); when fixing a bug class, sweep **`codegen/` and `latex_gen.py`** plus **CLI and REPL**; delegated docs must **`txt2tex --tex-only`**-verify every rendered snippet; documents **`make complexity-report`** and flags **`lexer.py`** / **`parser_pkg/expressions.py`** as known high-complexity hotspots.
> 
> **`docs/DESIGN.md`** introduces a **Maintenance invariants** section at the top of the architecture doc: (1) relational algebra must not be emitted into fuzz-checked Z boxes — new box sites must call **`_reject_ra_in_box`**; (2) Z-paragraph continuation indentation follows **`_binding_depth`** / **`\t{n}`** for every binder including comprehensions and lambda.
> 
> **`docs/complexity-report.{md,json}`** is regenerated at commit **`dde0216`** (prior snapshot 2026-05-25). Reported deltas include D-or-worse functions **23 → 22**, lizard warnings **26 → 25**, and several codegen modules showing improved maintainability index after recent guard work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9de56317528f6781f420fa4085bfa197fd304158. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->