### PR TITLE
feat(nofuzz): NOFUZZ modifier for rendered-but-unchecked Z boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-07-05
+
+### Added
+
+- **`NOFUZZ:` — mark a single Z box as rendered-but-not-type-checked.** For
+  genuine Z that fuzz's grammar cannot parse — the canonical case being numeric
+  exponentiation `n^2`, which the Z toolkit has no operator for (fuzz reads `^`
+  as *relational iteration*, so `n = n^2` with `n : N` is a type error even
+  though it is the intended mathematics). Syntax is a one-line modifier prefix
+  carrying a mandatory reason:
+
+  ```text
+  NOFUZZ: fuzz reads ^ as relational iteration, not exponentiation
+  axdef
+    square : N -> N
+  where
+    forall n : N | square(n) = n^2
+  end
+  ```
+
+  The box renders **visually identical to the checked box of the same kind** —
+  no banner, no special frame — with one mandatory, non-suppressible italic note
+  directly beneath it: `† not type-checked — <reason>`. fuzz skips the box
+  entirely (it is emitted in a fuzz-invisible twin environment —
+  `axdefnofuzz` / `zednofuzz` / `schemanofuzz`), so the rest of the document
+  still type-checks.
+- **Reject-if-clean lint.** `NOFUZZ:` is only for content fuzz genuinely cannot
+  check. If the wrapped content type-checks cleanly, the build fails
+  (`NOFUZZ block at line N type-checks cleanly under fuzz — use a plain box
+  instead`), so a `NOFUZZ:` waiver cannot paper over a real error.
+- Supported box kinds: `axdef`, `schema`, and `zed`-paragraphs (abbreviations,
+  given sets, free types). `gendef` is deferred — marking one raises a clear
+  "not yet implemented" error rather than emitting an undefined environment.
+
 ## [2.0.5] - 2026-07-05
 
 ### Fixed

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -3491,3 +3491,96 @@ mixed indentation and nested arrays with different left edges (ragged). Fix:
 - Regression coverage: `tests/test_display_math_indent.py`. Fixture churn:
   `bindings.tex`, `relational_calculus.tex`, `q2d_demo.tex` (indentation/array
   structure only).
+
+## ADR: NOFUZZ — Marking a Box Fuzz Genuinely Cannot Check
+
+**Problem.** fuzz rejects genuine Z that its grammar cannot express. The
+canonical case is numeric exponentiation: Z's toolkit has no arithmetic
+`^` operator. `\bsup...\esup` is defined for exactly one purpose —
+relation iteration (`R^n`, Z RM's `iter`) — so `n = n^2` with `n : N` is a
+fuzz type error even though it is exactly the mathematics the author
+intends. Before NOFUZZ, an author hitting this had no way to keep the box
+both boxed (so it reads as Z to a Z-trained reader) and present in a
+document that otherwise passes `fuzz`.
+
+**Alternatives rejected.**
+
+1. *A file-level exclusion list in CI* (skip fuzz on named files/lines).
+   Rejected: brittle (breaks silently when line numbers shift), and the
+   waiver is invisible in the document itself — a reader of the PDF has no
+   way to know a box wasn't checked. The waiver must live where the reader
+   can see it, not in a CI config the reader never opens.
+2. *A loud dashed-banner "unchecked" frame* around the box. Rejected: it
+   stops reading as Z. The box shape (rules, weight, indentation) is part
+   of what signals "this is a formal Z paragraph" to a Z-trained reader;
+   wrapping it in a warning frame undermines that signal for content that
+   is, in fact, genuine Z — just Z fuzz's grammar cannot parse.
+
+**Decision.** Per-box-kind fuzz-invisible twin environments —
+`axdefnofuzz`, `schemanofuzz`, `zednofuzz` — that render **byte-identical**
+to the checked box of the same kind (same rules, same shape, same
+indentation), plus one mandatory line directly beneath the box:
+
+```text
+† not type-checked — <reason>
+```
+
+"not type-checked" is fixed text; only the reason (mandatory, supplied by
+the author on the `NOFUZZ: <reason>` modifier line) varies, and there is
+no flag to suppress the note. fuzz's typechecker binary is a static
+scanner over the `.tex` source that recognizes the literal strings
+`\begin{zed}`, `\begin{axdef}`, `\begin{schema}` (etc.); the `*nofuzz`
+names are deliberately outside that vocabulary, so fuzz skips the box
+structurally — it never sees the offending predicate, and the rest of the
+document still type-checks normally. The twins are built from the same
+low-level fuzz.sty primitives (`\@zed`, `\@zlign`, `\@zedline`, ...) as
+their checked counterparts, not by wrapping a real `\begin{axdef}` —
+wrapping would put a checkable delimiter back in fuzz's path and defeat
+the skip.
+
+**Rationale.** The box is the formality signal in this document's
+vocabulary — that is precisely why NOFUZZ reuses the real box shape
+rather than inventing a new one. Reusing that signal for content fuzz
+cannot check would be dishonest without a compensating cost, so the
+mandatory "not type-checked — reason" line is the honesty tax: an author
+gets to keep the box, but never gets to keep the appearance of having
+been checked. The note is a fixed sentence rather than free-form
+commentary so a reader can grep a document for the constant phrase
+"not type-checked" and enumerate every waiver, regardless of author.
+
+**Enforced by a reject-if-clean lint.** NOFUZZ is a waiver for content
+fuzz genuinely cannot parse, not a way to silence a real type error. Each
+NOFUZZ box's body is independently probed by wrapping the same body lines
+in the corresponding *checked* environment and asking fuzz whether it
+type-checks on its own; if it does, the build fails —
+
+```text
+Error: NOFUZZ block at line N type-checks cleanly under fuzz — use a
+plain box instead; NOFUZZ is only for content fuzz genuinely cannot
+check.
+```
+
+— so a `NOFUZZ:` label cannot be used to paper over an author's actual
+mistake.
+
+**Scope.** `axdef`, `schema`, and `zed`-producing paragraphs (given
+types, free types, abbreviations — all three consolidate into one `zed`
+box) are supported. `gendef` is deferred: no `gendefnofuzz` environment
+exists yet (fuzz's real `\gendef` draws a bracketed generic-parameter tab
+via `\@gendef`/`\@ngendef` that the twin would need to reproduce), so
+marking a `gendef` with `NOFUZZ:` raises a clear "not yet implemented"
+error rather than emitting an undefined LaTeX environment that would
+break compilation.
+
+**Implementation.** `zednofuzz.sty` (new, requires `fuzz.sty`) defines the
+three twin environments plus `\@nfreason`/`\@nftopline`. Parser:
+`_parse_nofuzz_modifier` in `src/txt2tex/parser.py` re-stamps the
+immediately following `AxDef`/`Schema`/`GenDef`/`GivenType`/`FreeType`/
+`Abbreviation` node with a `nofuzz_reason` field via `dataclasses.replace`
+— so NOFUZZ content is parsed through the exact same grammar as the
+checked form, with rendering as the only divergence. Codegen
+(`codegen/paragraphs.py`, `codegen/schemas.py`) swaps the emitted
+environment name when `nofuzz_reason` is set and stages a
+`NoFuzzLintItem` (line, reason, checked-form probe snippet) per box; the
+CLI (`cli.py`) runs the reject-if-clean probe against each staged item
+after the full document has been generated.

--- a/docs/guides/MISSING_FEATURES.md
+++ b/docs/guides/MISSING_FEATURES.md
@@ -91,7 +91,7 @@ The right workaround depends on what the exercise is asking for:
 
 ## Known Limitations
 
-1. **Superscript `^`**: Only for relation iteration (`R^n`), not arithmetic (`x^2`). Write `x * x` for squaring.
+1. **Superscript `^`**: Only for relation iteration (`R^n`), not arithmetic (`x^2`). Write `x * x` for squaring. If you need the literal `n^2` form to appear (e.g. teaching material), mark the containing `axdef`/`schema`/`zed`-paragraph box with `NOFUZZ:` — see [USER_GUIDE.md § NOFUZZ](USER_GUIDE.md#nofuzz--marking-content-fuzz-cant-check). `NOFUZZ:` renders the box normally (fuzz just skips checking it) and is enforced by a reject-if-clean lint, so it can't be used to hide an actual type error. `gendef` boxes are not yet supported by `NOFUZZ:` (`gendefnofuzz` is deferred — no LaTeX environment exists yet).
 2. **Tuple projection**: Only named fields (`x.field`), not positional (`.1`, `.2`).
 3. **fuzz parallel-binding in set comprehensions**: fuzz requires sequential binding of schema text (Z RM §3.5 allows parallel; fuzz tightens this). The generator automatically works around this for `forall`/`exists`/`exists1`/`mu`/`lambda` by reordering declarations. Set comprehensions using multiple schemas with cross-references raise a clear error directing you to rewrite as a single declaration sequence.
 4. **`id` is reserved**: maps to `\id` (the identity relation operator). It cannot be used as a schema-component name, variable, or relation name. Use `tid`, `rid`, `entityId`, etc. instead. (Other Z RM names that are similarly reserved: `dom`, `ran`, `inv`, `pre` — anything in the standard Z toolkit.)
@@ -163,6 +163,18 @@ These items were missing in earlier versions and are now shipped:
 - **Horizontal schema definitions `Name defs Schema-Exp`** — supports full schema calculus RHS expressions (Phase 1.3)
 - **Dependent-domain lambda/mu** — generator detects multi-decl expressions where later declarations depend on earlier ones and emits the correct Spivey collapsed form (fix `92823b7`)
 - **Schema calculus**: composition (`;`), piping (`>>`), hiding (`hide`), projection (`project`) — all shipped
+- **NOFUZZ: marking content fuzz can't check** (2026-07-05) — resolves the
+  "content fuzz genuinely can't check" gap (e.g. arithmetic `n^2`, listed
+  above under Known Limitations). A `NOFUZZ: <reason>` modifier line marks
+  an `axdef`, `schema`, or `zed`-producing paragraph (given set / free type
+  / abbreviation) as rendered but not type-checked; the box renders
+  identically to the checked kind plus one mandatory under-box note, and a
+  reject-if-clean lint fails the build if the wrapped content actually
+  type-checks cleanly on its own. `gendef` boxes remain unsupported
+  (`gendefnofuzz` is deferred — no LaTeX environment exists yet; marking
+  one errors with a clear message). See
+  [USER_GUIDE.md § NOFUZZ](USER_GUIDE.md#nofuzz--marking-content-fuzz-cant-check)
+  and `docs/DESIGN.md § ADR: NOFUZZ`.
 
 ---
 

--- a/docs/guides/USER_GUIDE.md
+++ b/docs/guides/USER_GUIDE.md
@@ -2880,6 +2880,22 @@ than shipping a mislabeled waiver.
 | Given set / free type / abbreviation | Yes | `zednofuzz` |
 | `gendef` | Not yet | Errors: `gendefnofuzz not yet implemented — mark support pending (NOFUZZ cannot be applied to a gendef block)` |
 
+### Limitations
+
+- **A name declared inside a NOFUZZ box is invisible to fuzz.** The
+  `*nofuzz` environment is skipped by fuzz's scanner, so any name the box
+  declares (a function, a given set) is not known to the type-checker. If a
+  *checked* box then references that name, fuzz reports it as undeclared and
+  the build fails. Use the **axdef bridge**: declare the name's *type* in a
+  plain (checked) `axdef`, and put only the genuinely uncheckable predicate
+  under `NOFUZZ:`. That way the name is visible to fuzz and the offending
+  predicate is still waived.
+- These uses are rejected with a clear error, not silently mishandled:
+  generic parameters on the marked box; `NOFUZZ:` under `--zed` (zed-cm mode
+  does no type-checking); stacking `NOFUZZ:` twice; and `NOFUZZ:` on a
+  relational-algebra abbreviation (already display-math, so nothing to
+  waive).
+
 ---
 
 ## Proof Trees

--- a/docs/guides/USER_GUIDE.md
+++ b/docs/guides/USER_GUIDE.md
@@ -18,7 +18,8 @@ txt2tex emits standard LaTeX, so you can take any `.tex` file to Overleaf or you
 10. [Functions](#functions)
 11. [Sequences](#sequences)
 12. [Schema Notation](#schema-notation)
-13. [Proof Trees](#proof-trees)
+13. [NOFUZZ — Marking Content Fuzz Can't Check](#nofuzz--marking-content-fuzz-cant-check)
+14. [Proof Trees](#proof-trees)
 
 ---
 
@@ -1972,6 +1973,9 @@ R^n              →  Rⁿ          [n-fold relation composition]
 
 - Manual multiplication: `x * x` for x², `x * x * x` for x³
 - Define a pow function (see examples/06_definitions/pow_function.txt)
+- If you need `n^2` to appear literally (e.g. teaching material that must
+  show the exponent), mark the box with `NOFUZZ:` — see
+  [NOFUZZ — Marking Content Fuzz Can't Check](#nofuzz--marking-content-fuzz-cant-check)
 
 **Common mistake:**
 
@@ -2739,6 +2743,145 @@ remains a declaration separator — this is unchanged.
 
 ---
 
+## NOFUZZ — Marking Content Fuzz Can't Check
+
+Some genuine Z can't be parsed by the fuzz typechecker. The clearest
+example is numeric exponentiation: Z has no `^` operator for arithmetic.
+fuzz reads `^` as *relational iteration* (`R^n`, applying a relation to
+itself `n` times), so `n = n^2` with `n : N` fails as a type error even
+though it's exactly the arithmetic you meant.
+
+`NOFUZZ:` marks a single box — an `axdef`, `schema`, or a
+`zed`-producing paragraph (given set, free type, abbreviation) — as
+**rendered but deliberately not type-checked**. Use it only when the
+content is genuinely correct Z that fuzz's grammar can't express — not
+as a way to hide a real mistake (see [Reject-if-clean](#reject-if-clean),
+below).
+
+### Syntax
+
+`NOFUZZ:` is a one-line modifier immediately before the box it applies
+to. The reason is mandatory and runs to the end of the line:
+
+```text
+NOFUZZ: <reason>
+<axdef | schema | given set | free type | abbreviation>
+```
+
+### Example
+
+Input:
+
+```text
+NOFUZZ: fuzz reads ^ as relational iteration, not exponentiation
+axdef
+  square : N -> N
+where
+  forall n : N | square(n) = n^2
+end
+```
+
+Run `txt2tex file.txt --tex-only` and the box comes out as:
+
+```latex
+\begin{axdefnofuzz}{fuzz reads \textasciicircum{} as relational iteration, not exponentiation}
+square : \nat \fun \nat
+\where
+\forall n : \nat @ square(n) = n \bsup 2 \esup
+\end{axdefnofuzz}
+```
+
+A schema works the same way — `NOFUZZ:` immediately before `schema
+Squarer` produces `\begin{schemanofuzz}{Squarer}{<reason>}...
+\end{schemanofuzz}`:
+
+```text
+NOFUZZ: fuzz reads ^ as relational iteration, not exponentiation
+schema Squarer
+  n, result : N
+where
+  result = n^2
+end
+```
+
+```latex
+\begin{schemanofuzz}{Squarer}{fuzz reads \textasciicircum{} as relational iteration, not exponentiation}
+n : \nat \\
+result : \nat
+\where
+result = n \bsup 2 \esup
+\end{schemanofuzz}
+```
+
+An abbreviation, given set, or free type all render into `zednofuzz`
+instead of `zed`:
+
+```text
+NOFUZZ: same reason, abbreviation form
+squares == { n : N | n = n^2 }
+```
+
+```latex
+\begin{zednofuzz}{same reason, abbreviation form}
+squares == \{~ n : \nat | n = n \bsup 2 \esup ~\}
+\end{zednofuzz}
+```
+
+### How it renders
+
+The box is **visually identical to the checked box of the same kind** —
+same rules, same shape, same indentation. There is no banner and no
+special frame. The only mark is one line directly beneath the box:
+
+```text
+† not type-checked — fuzz reads ^ as relational iteration, not exponentiation
+```
+
+"not type-checked" is fixed text; only the reason after the dash comes
+from your `NOFUZZ:` line. This note is mandatory — there is no flag or
+option that suppresses it.
+
+fuzz never sees the box: `axdefnofuzz` / `schemanofuzz` / `zednofuzz`
+are environment names outside the literal set fuzz's typechecker scans
+for (`\begin{axdef}`, `\begin{schema}`, `\begin{zed}`, ...), so it skips
+the box entirely and the rest of the document still type-checks.
+
+### Reject-if-clean
+
+NOFUZZ exists for content fuzz genuinely cannot check — not as a
+shortcut past a real type error. If the box you wrap actually
+type-checks fine on its own, the build **fails**:
+
+```text
+Error: NOFUZZ block at line 4 type-checks cleanly under fuzz — use a plain box instead; NOFUZZ is only for content fuzz genuinely cannot check.
+```
+
+For example, wrapping a correct axdef that fuzz would happily accept
+unwrapped:
+
+```text
+NOFUZZ: this is actually fine, mislabeled on purpose
+axdef
+  double : N -> N
+where
+  forall n : N | double(n) = n + n
+end
+```
+
+produces exactly that error and exit code 1 — the build stops rather
+than shipping a mislabeled waiver.
+
+### Supported box kinds
+
+| Box kind | Supported | Rendered as |
+|---|---|---|
+| `axdef` | Yes | `axdefnofuzz` |
+| `schema` | Yes | `schemanofuzz` |
+| Given set / free type / abbreviation | Yes | `zednofuzz` |
+| `gendef` | Not yet | Errors: `gendefnofuzz not yet implemented — mark support pending (NOFUZZ cannot be applied to a gendef block)` |
+
+---
+
 ## Proof Trees
 
 Natural deduction proofs using indentation-based syntax. For a
@@ -3456,6 +3599,9 @@ R^{n+1}          →  Rⁿ⁺¹        [braces group multi-char superscripts]
 
 - Use manual multiplication: `x * x` for x², `x * x * x` for x³
 - Define a `pow` function (see examples/06_definitions/pow_function.txt)
+- If the literal `n^2` form is what you need on the page, mark the box
+  with `NOFUZZ:` — see
+  [NOFUZZ — Marking Content Fuzz Can't Check](#nofuzz--marking-content-fuzz-cant-check)
 
 **Why this limitation exists:** Fuzz's `\bsup...\esup` command is specifically for the `iter` operator, which applies a relation to itself n times. It expects a relation type, not a number type. See the Z Reference Manual section on `iter` for details.
 

--- a/src/txt2tex/__version__.py
+++ b/src/txt2tex/__version__.py
@@ -1,3 +1,3 @@
 """Defines the version of the txt2tex package."""
 
-__version__ = "2.0.5"
+__version__ = "2.1.0"

--- a/src/txt2tex/ast_nodes.py
+++ b/src/txt2tex/ast_nodes.py
@@ -1076,9 +1076,16 @@ class InfruleBlock(ASTNode):
 
 @dataclass(frozen=True)
 class GivenType(ASTNode):
-    """Given type declaration (given A, B, C)."""
+    """Given type declaration (given A, B, C).
+
+    ``nofuzz_reason``, when set, marks this given type as preceded by a
+    ``NOFUZZ: <reason>`` modifier: it renders in a ``zednofuzz`` box
+    instead of ``zed`` and is exempt from fuzz type-checking (jms-settled
+    design; see the NOFUZZ feature).
+    """
 
     names: list[str]
+    nofuzz_reason: str | None = None
 
 
 @dataclass(frozen=True)
@@ -1115,6 +1122,7 @@ class FreeType(ASTNode):
 
     name: str
     branches: list[FreeBranch]  # List of constructor branches
+    nofuzz_reason: str | None = None  # See GivenType.nofuzz_reason
 
 
 @dataclass(frozen=True)
@@ -1171,6 +1179,7 @@ class Abbreviation(ASTNode):
     name: str
     expression: Expr
     generic_params: list[str] | None = None  # Optional generic parameters
+    nofuzz_reason: str | None = None  # See GivenType.nofuzz_reason
 
 
 @dataclass(frozen=True)
@@ -1225,6 +1234,7 @@ class AxDef(ASTNode):
     declarations: list[Declaration | SchemaInclusion]
     predicates: list[list[Expr]]  # Groups of predicates (separated by blank lines)
     generic_params: list[str] | None = None  # Optional generic parameters
+    nofuzz_reason: str | None = None  # See GivenType.nofuzz_reason
 
 
 @dataclass(frozen=True)
@@ -1241,11 +1251,16 @@ class GenDef(ASTNode):
     where
       forall x : X; y : Y @ fst(x, y) = x
     end
+
+    ``nofuzz_reason`` is accepted for grammar symmetry with AxDef/Schema,
+    but codegen rejects it: no ``gendefnofuzz`` environment exists yet
+    (see ``_generate_gendef``).
     """
 
     generic_params: list[str]  # Required generic parameters
     declarations: list[Declaration | SchemaInclusion]
     predicates: list[list[Expr]]  # Groups of predicates (separated by blank lines)
+    nofuzz_reason: str | None = None  # See GivenType.nofuzz_reason; not yet supported
 
 
 @dataclass(frozen=True)
@@ -1265,6 +1280,7 @@ class Schema(ASTNode):
     declarations: list[Declaration | SchemaInclusion]
     predicates: list[list[Expr]]  # Groups of predicates (separated by blank lines)
     generic_params: list[str] | None = None  # Optional generic parameters
+    nofuzz_reason: str | None = None  # See GivenType.nofuzz_reason
 
 
 @dataclass(frozen=True)

--- a/src/txt2tex/cli.py
+++ b/src/txt2tex/cli.py
@@ -11,8 +11,8 @@ from pathlib import Path
 
 from txt2tex.__version__ import __version__
 from txt2tex.codegen.paragraphs import (
-    NoFuzzGenDefNotImplementedError,
     NoFuzzLintItem,
+    NoFuzzUnsupportedError,
     RaInZedError,
 )
 from txt2tex.codegen.text_pipeline import InlineMathError
@@ -366,7 +366,7 @@ def main() -> int:
     except RaInZedError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
-    except NoFuzzGenDefNotImplementedError as e:
+    except NoFuzzUnsupportedError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
 

--- a/src/txt2tex/cli.py
+++ b/src/txt2tex/cli.py
@@ -122,6 +122,7 @@ def lint_nofuzz_block(item: NoFuzzLintItem) -> bool | None:
                 cwd=work_dir,
                 capture_output=True,
                 text=True,
+                errors="replace",
                 check=False,
             )
         finally:

--- a/src/txt2tex/cli.py
+++ b/src/txt2tex/cli.py
@@ -10,7 +10,11 @@ import tempfile
 from pathlib import Path
 
 from txt2tex.__version__ import __version__
-from txt2tex.codegen.paragraphs import RaInZedError
+from txt2tex.codegen.paragraphs import (
+    NoFuzzGenDefNotImplementedError,
+    NoFuzzLintItem,
+    RaInZedError,
+)
 from txt2tex.codegen.text_pipeline import InlineMathError
 from txt2tex.compile import compile_pdf, copy_latex_files, format_tex, get_latex_dir
 from txt2tex.errors import ErrorFormatter
@@ -66,6 +70,61 @@ def typecheck_fuzz(tex_path: Path) -> bool:
         # Clean up copied files
         for copied in copied_files:
             copied.unlink(missing_ok=True)
+
+
+def lint_nofuzz_block(item: NoFuzzLintItem) -> bool | None:
+    """Check whether a NOFUZZ box's body genuinely fails fuzz on its own.
+
+    NOFUZZ exists to waive genuine Z content fuzz cannot parse.  A box
+    whose body type-checks cleanly in isolation is a mislabeled waiver —
+    it should be a plain checked box instead.  This probes exactly that:
+    ``item.probe_snippet`` is already a complete, self-contained checked
+    fragment (``\\begin{axdef}...\\end{axdef}``, ``\\begin{zed}...\\end{zed}``,
+    or ``\\begin{schema}{name}...\\end{schema}``, matching the NOFUZZ box's
+    own kind) -- this drops it into a minimal fuzz document and runs the
+    ``fuzz`` binary.
+
+    Args:
+        item: The NOFUZZ box's checked-form probe, staged during codegen.
+
+    Returns:
+        True if fuzz rejected the body (the waiver is justified).
+        False if fuzz accepted the body cleanly (use a plain box instead).
+        None if the fuzz binary is not installed (lint skipped).
+    """
+    fuzz = shutil.which("fuzz")
+    if fuzz is None:
+        return None
+
+    probe = (
+        "\\documentclass[a4paper,10pt,fleqn]{article}\n"
+        "\\usepackage{fuzz}\n"
+        "\\usepackage{schemapk}\n"
+        "\\usepackage{zed-maths}\n"
+        "\\usepackage{zed-proof}\n"
+        "\\begin{document}\n"
+        f"{item.probe_snippet}\n"
+        "\\end{document}\n"
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        work_dir = Path(tmpdir)
+        tex_path = work_dir / "nofuzz_probe.tex"
+        tex_path.write_text(probe)
+        copied_files = copy_latex_files(work_dir)
+        try:
+            result = subprocess.run(  # noqa: S603
+                [fuzz, tex_path.name],
+                cwd=work_dir,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        finally:
+            for copied in copied_files:
+                copied.unlink(missing_ok=True)
+
+    return result.returncode != 0
 
 
 def _check_latex_package(pdflatex: str, package: str) -> bool:
@@ -307,6 +366,9 @@ def main() -> int:
     except RaInZedError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
+    except NoFuzzGenDefNotImplementedError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
 
     # Emit any overflow warnings
     generator.emit_warnings()
@@ -329,6 +391,32 @@ def main() -> int:
     # Format with tex-fmt (if requested)
     if args.format:
         format_tex(output_path)
+
+    # Lint NOFUZZ blocks: each one must genuinely fail fuzz on its own — a
+    # block that type-checks cleanly in isolation is a mislabeled waiver.
+    # Skips gracefully (with a note) when fuzz is not installed, same
+    # degradation as the full-document typecheck below.
+    if not args.zed:
+        fuzz_missing_noted = False
+        for nofuzz_item in generator.nofuzz_lint_items:
+            outcome = lint_nofuzz_block(nofuzz_item)
+            if outcome is None:
+                if not fuzz_missing_noted:
+                    print(
+                        "Note: fuzz typechecker not found. Skipping NOFUZZ lint.",
+                        file=sys.stderr,
+                    )
+                    fuzz_missing_noted = True
+                continue
+            if outcome is False:
+                print(
+                    f"Error: NOFUZZ block at line {nofuzz_item.line} "
+                    "type-checks cleanly under fuzz — use a plain box "
+                    "instead; NOFUZZ is only for content fuzz genuinely "
+                    "cannot check.",
+                    file=sys.stderr,
+                )
+                return 1
 
     # Type check with fuzz (if available and using fuzz package)
     if not args.zed:

--- a/src/txt2tex/cli.py
+++ b/src/txt2tex/cli.py
@@ -88,8 +88,12 @@ def lint_nofuzz_block(item: NoFuzzLintItem) -> bool | None:
         item: The NOFUZZ box's checked-form probe, staged during codegen.
 
     Returns:
-        True if fuzz rejected the body (the waiver is justified).
-        False if fuzz accepted the body cleanly (use a plain box instead).
+        True if fuzz rejected the body with a genuine parse/type error
+            (the waiver is justified).
+        False if fuzz accepted the body cleanly, or rejected it *only* on
+            undeclared identifiers -- the probe is the box in isolation, so
+            an undeclared-name failure means the body may well be checkable
+            in context (a mislabeled waiver), not genuinely unparseable Z.
         None if the fuzz binary is not installed (lint skipped).
     """
     fuzz = shutil.which("fuzz")
@@ -124,7 +128,19 @@ def lint_nofuzz_block(item: NoFuzzLintItem) -> bool | None:
             for copied in copied_files:
                 copied.unlink(missing_ok=True)
 
-    return result.returncode != 0
+    output = f"{result.stdout}\n{result.stderr}"
+    if result.returncode == 0:
+        return False
+    # The probe is the box in isolation, so it can fail merely because it
+    # references names declared elsewhere in the document ("Identifier X is
+    # not declared") rather than because its own Z is unparseable. Only a
+    # genuine parse/type error justifies the waiver. fuzz reports every error
+    # (not just the first), so a failure whose error lines are *all*
+    # undeclared-name errors means the body is otherwise checkable in context.
+    error_lines = [ln for ln in output.splitlines() if ln.lstrip().startswith('"')]
+    if not error_lines:
+        return True
+    return any("is not declared" not in ln for ln in error_lines)
 
 
 def _check_latex_package(pdflatex: str, package: str) -> bool:
@@ -411,9 +427,9 @@ def main() -> int:
             if outcome is False:
                 print(
                     f"Error: NOFUZZ block at line {nofuzz_item.line} "
-                    "type-checks cleanly under fuzz — use a plain box "
-                    "instead; NOFUZZ is only for content fuzz genuinely "
-                    "cannot check.",
+                    "type-checks cleanly (or fails only on names declared "
+                    "elsewhere in the document) — use a plain box instead; "
+                    "NOFUZZ is only for content fuzz genuinely cannot parse.",
                     file=sys.stderr,
                 )
                 return 1

--- a/src/txt2tex/codegen/paragraphs.py
+++ b/src/txt2tex/codegen/paragraphs.py
@@ -368,6 +368,18 @@ class _ParagraphsCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
         else:
             abbrev = f"{name_latex} == {expr_latex}"
 
+        # A relational-algebra RHS is already emitted as display math outside
+        # any Z environment (fuzz never checks it, and RA is barred from a
+        # box), so a NOFUZZ waiver has nothing to waive -- reject rather than
+        # silently drop the note and the reject-if-clean probe.
+        if is_relational_rhs and node.nofuzz_reason is not None:
+            msg = (
+                "NOFUZZ cannot be applied to a relational-algebra abbreviation "
+                "— RA is rendered as display math outside any fuzz-checked box, "
+                "so there is nothing to waive."
+            )
+            raise NoFuzzUnsupportedError(msg)
+
         # Pick the wrapping based on RHS content
         if is_relational_rhs:
             # Dual-emit for binding set comprehensions: hidden copy with

--- a/src/txt2tex/codegen/paragraphs.py
+++ b/src/txt2tex/codegen/paragraphs.py
@@ -10,6 +10,8 @@ changed.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from txt2tex.ast_nodes import (
     Abbreviation,
     AxDef,
@@ -30,6 +32,40 @@ from txt2tex.ast_nodes import (
 from txt2tex.codegen._dispatch import CodegenDispatch, item_register
 
 
+@dataclass(frozen=True)
+class NoFuzzLintItem:
+    """One NOFUZZ box's throwaway checked-form probe, staged for the lint.
+
+    Populated during code generation wherever ``node.nofuzz_reason`` is
+    set (``_generate_given_type``, ``_generate_free_type``,
+    ``_generate_abbreviation``, ``_generate_axdef``, and schema's
+    ``_generate_schema``); consumed by the CLI, once the full document has
+    been generated, via ``LaTeXGenerator.nofuzz_lint_items``.
+
+    ``probe_snippet`` is a complete, self-contained checked-box LaTeX
+    fragment -- e.g. ``\\begin{axdef}...\\end{axdef}`` or
+    ``\\begin{zed}...\\end{zed}`` -- built from the *same* body lines the
+    real NOFUZZ box renders, but wrapped in the plain (fuzz-checked)
+    environment instead of its ``*nofuzz`` twin.  The CLI drops this
+    verbatim into a minimal document and asks fuzz whether it type-checks
+    on its own.
+    """
+
+    line: int
+    reason: str
+    probe_snippet: str
+
+
+class NoFuzzGenDefNotImplementedError(Exception):
+    """Raised when a NOFUZZ modifier marks a ``gendef``.
+
+    No ``gendefnofuzz`` LaTeX environment exists yet (unlike
+    ``axdefnofuzz``/``zednofuzz``/``schemanofuzz``).  Rather than emit an
+    undefined environment that would break compilation, codegen rejects
+    the input with an actionable message pointing at the gap.
+    """
+
+
 class RaInZedError(Exception):
     """Raised when a relational-algebra construct sits inside a boxed Z paragraph.
 
@@ -47,6 +83,10 @@ class RaInZedError(Exception):
 
 class _ParagraphsCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
     """Mixin: handlers for Z paragraph constructs."""
+
+    # Populated on LaTeXGenerator (see latex_gen.py __init__/_resolve_toc_depth);
+    # declared here so mypy/pyright resolve self.nofuzz_lint_items in this file.
+    nofuzz_lint_items: list[NoFuzzLintItem]
 
     def _reject_ra_in_box(
         self, expr: Expr, line: int, rendered: str, block_kind: str | None
@@ -73,11 +113,30 @@ class _ParagraphsCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
 
     @item_register.register(GivenType)
     def _generate_given_type(self, node: GivenType) -> list[str]:
-        """Generate LaTeX for given type declaration."""
+        """Generate LaTeX for given type declaration.
+
+        ``nofuzz_reason`` (set by a preceding ``NOFUZZ:`` modifier) swaps
+        the wrapper to ``zednofuzz`` and stages the plain-``zed`` probe for
+        the CLI's reject-if-clean lint; the body -- ``[A, B, C]`` -- is
+        identical either way.
+        """
         lines: list[str] = []
-        # Generate as: [A, B, C] in zed environment
         names_str = ", ".join(node.names)
-        lines.append(f"\\begin{{zed}}[{names_str}]\\end{{zed}}")
+        body = f"[{names_str}]"
+        if node.nofuzz_reason is None:
+            lines.append(f"\\begin{{zed}}{body}\\end{{zed}}")
+        else:
+            self.nofuzz_lint_items.append(
+                NoFuzzLintItem(
+                    line=node.line,
+                    reason=node.nofuzz_reason,
+                    probe_snippet=f"\\begin{{zed}}{body}\\end{{zed}}",
+                )
+            )
+            escaped_reason = self._escape_latex_text(node.nofuzz_reason)
+            lines.append(
+                f"\\begin{{zednofuzz}}{{{escaped_reason}}}{body}\\end{{zednofuzz}}"
+            )
         lines.append("")
         return lines
 
@@ -89,8 +148,13 @@ class _ParagraphsCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
         - Status ::= active | inactive (simple branches)
         - Tree ::= stalk | leaf \\ldata N \\rdata |
           branch \\ldata Tree \\cross Tree \\rdata
+
+        ``nofuzz_reason`` swaps the wrapper to ``zednofuzz`` and stages
+        the plain-``zed`` probe for the CLI's reject-if-clean lint; see
+        ``_generate_given_type`` for the identical pattern.
         """
         lines: list[str] = []
+        block_kind = "zednofuzz" if node.nofuzz_reason is not None else "zed"
 
         # Generate each branch with proper LaTeX formatting
         branch_strs: list[str] = []
@@ -109,7 +173,7 @@ class _ParagraphsCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
                         param_expr = branch.parameters.elements[0]
                         params_latex = self.generate_expr(param_expr)
                         self._reject_ra_in_box(
-                            param_expr, param_expr.line, params_latex, "zed"
+                            param_expr, param_expr.line, params_latex, block_kind
                         )
                     else:
                         params_latex = ""
@@ -119,15 +183,28 @@ class _ParagraphsCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
                         branch.parameters,
                         branch.parameters.line,
                         params_latex,
-                        "zed",
+                        block_kind,
                     )
                 branch_strs.append(f"{branch.name} \\ldata {params_latex} \\rdata")
 
         # Join branches with |
         branches_str = " | ".join(branch_strs)
+        body = f"{node.name} ::= {branches_str}"
 
-        # Wrap in zed environment for proper formatting
-        lines.append(f"\\begin{{zed}}{node.name} ::= {branches_str}\\end{{zed}}")
+        if node.nofuzz_reason is None:
+            lines.append(f"\\begin{{zed}}{body}\\end{{zed}}")
+        else:
+            self.nofuzz_lint_items.append(
+                NoFuzzLintItem(
+                    line=node.line,
+                    reason=node.nofuzz_reason,
+                    probe_snippet=f"\\begin{{zed}}{body}\\end{{zed}}",
+                )
+            )
+            escaped_reason = self._escape_latex_text(node.nofuzz_reason)
+            lines.append(
+                f"\\begin{{zednofuzz}}{{{escaped_reason}}}{body}\\end{{zednofuzz}}"
+            )
         lines.append("")
         return lines
 
@@ -311,16 +388,32 @@ class _ParagraphsCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
             else:
                 lines.append(f"${abbrev}$")
         else:
-            # Pure Z RHS — emit inside a zed paragraph for fuzz type-checking
+            # Pure Z RHS — emit inside a zed paragraph for fuzz type-checking.
+            # nofuzz_reason swaps the wrapper to zednofuzz and stages the
+            # plain-zed probe for the CLI's reject-if-clean lint.
+            block_kind = "zednofuzz" if node.nofuzz_reason is not None else "zed"
             self._check_overflow(
                 abbrev,
                 node.line,
-                "zed abbreviation",
+                f"{block_kind} abbreviation",
                 f"{node.name} == ...",
             )
-            lines.append("\\begin{zed}")
-            lines.append(abbrev)
-            lines.append("\\end{zed}")
+            if node.nofuzz_reason is None:
+                lines.append("\\begin{zed}")
+                lines.append(abbrev)
+                lines.append("\\end{zed}")
+            else:
+                self.nofuzz_lint_items.append(
+                    NoFuzzLintItem(
+                        line=node.line,
+                        reason=node.nofuzz_reason,
+                        probe_snippet="\n".join([r"\begin{zed}", abbrev, r"\end{zed}"]),
+                    )
+                )
+                escaped_reason = self._escape_latex_text(node.nofuzz_reason)
+                lines.append(f"\\begin{{zednofuzz}}{{{escaped_reason}}}")
+                lines.append(abbrev)
+                lines.append("\\end{zednofuzz}")
 
         lines.append("")
         return lines
@@ -331,15 +424,14 @@ class _ParagraphsCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
 
         Supports optional generic parameters.
         Multiple declarations appear on separate lines with line breaks.
-        """
-        lines: list[str] = []
 
-        # Add generic parameters if present
-        if node.generic_params:
-            params_str = ", ".join(node.generic_params)
-            lines.append(f"\\begin{{axdef}}[{params_str}]")
-        else:
-            lines.append(r"\begin{axdef}")
+        ``nofuzz_reason`` swaps the wrapper to ``axdefnofuzz{<reason>}``
+        and stages a throwaway plain-``axdef`` probe (same body) for the
+        CLI's reject-if-clean lint -- the declaration/where-clause body
+        itself renders identically either way.
+        """
+        block_kind = "axdefnofuzz" if node.nofuzz_reason is not None else "axdef"
+        body_lines: list[str] = []
 
         # All expression generation inside this block uses Z-paragraph context so
         # that context-sensitive operators (e.g. o9 → \comp) emit correctly.
@@ -350,7 +442,7 @@ class _ParagraphsCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
             if node.declarations:
                 for i, decl in enumerate(node.declarations):
                     if isinstance(decl, SchemaInclusion):
-                        decl_line = self._emit_schema_inclusion(decl, "axdef")
+                        decl_line = self._emit_schema_inclusion(decl, block_kind)
                     else:
                         # Process variable through identifier logic
                         var_latex = self._generate_identifier(
@@ -384,24 +476,24 @@ class _ParagraphsCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
                         # Build full declaration line for overflow check
                         decl_line = f"{var_latex} : {type_latex}"
                         self._reject_ra_in_box(
-                            decl.type_expr, decl.type_expr.line, decl_line, "axdef"
+                            decl.type_expr, decl.type_expr.line, decl_line, block_kind
                         )
                         self._check_overflow(
                             decl_line,
                             decl.type_expr.line,
-                            "axdef declaration",
+                            f"{block_kind} declaration",
                             f"{decl.variable} : ...",
                         )
 
                     # Add line break after each declaration except the last
                     if i < len(node.declarations) - 1:
-                        lines.append(f"{decl_line} \\\\")
+                        body_lines.append(f"{decl_line} \\\\")
                     else:
-                        lines.append(decl_line)
+                        body_lines.append(decl_line)
 
             # Generate where clause if predicate groups exist
             if node.predicates and any(group for group in node.predicates):
-                lines.append(r"\where")
+                body_lines.append(r"\where")
 
                 # Iterate through predicate groups (separated by blank lines)
                 for group_idx, group in enumerate(node.predicates):
@@ -410,30 +502,51 @@ class _ParagraphsCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
                         # Pass parent=None for smart parenthesization
                         pred_latex = self.generate_expr(pred, parent=None)
 
-                        self._reject_ra_in_box(pred, pred.line, pred_latex, "axdef")
+                        self._reject_ra_in_box(pred, pred.line, pred_latex, block_kind)
 
                         # Auto-wrap long predicates; fall back to warning
                         self._check_overflow(
                             pred_latex,
                             pred.line,
-                            "axdef where clause",
+                            f"{block_kind} where clause",
                         )
 
                         # Use \\ as separator within group
                         if pred_idx < len(group) - 1:
-                            lines.append(f"{pred_latex} \\\\")
+                            body_lines.append(f"{pred_latex} \\\\")
                         else:
-                            lines.append(pred_latex)
+                            body_lines.append(pred_latex)
 
                     # Add \also between groups (not after last group)
                     if group_idx < len(node.predicates) - 1:
-                        lines.append(r"\also")
+                        body_lines.append(r"\also")
         finally:
             self._in_z_paragraph = prev_z
 
-        lines.append(r"\end{axdef}")
-        lines.append("")
+        generics_suffix = (
+            f"[{', '.join(node.generic_params)}]" if node.generic_params else ""
+        )
 
+        if node.nofuzz_reason is None:
+            lines: list[str] = [f"\\begin{{axdef}}{generics_suffix}"]
+            lines.extend(body_lines)
+            lines.append(r"\end{axdef}")
+            lines.append("")
+            return lines
+
+        probe_snippet = "\n".join(
+            [f"\\begin{{axdef}}{generics_suffix}", *body_lines, r"\end{axdef}"]
+        )
+        self.nofuzz_lint_items.append(
+            NoFuzzLintItem(
+                line=node.line, reason=node.nofuzz_reason, probe_snippet=probe_snippet
+            )
+        )
+        escaped_reason = self._escape_latex_text(node.nofuzz_reason)
+        lines = [f"\\begin{{axdefnofuzz}}{{{escaped_reason}}}{generics_suffix}"]
+        lines.extend(body_lines)
+        lines.append(r"\end{axdefnofuzz}")
+        lines.append("")
         return lines
 
     @item_register.register(GenDef)
@@ -442,7 +555,19 @@ class _ParagraphsCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
 
         Generic definitions always have generic parameters (required).
         Multiple declarations appear on separate lines with line breaks.
+
+        Raises:
+            NoFuzzGenDefNotImplementedError: if ``node.nofuzz_reason`` is
+                set.  No ``gendefnofuzz`` environment exists yet -- see
+                the exception's docstring.
         """
+        if node.nofuzz_reason is not None:
+            msg = (
+                "gendefnofuzz not yet implemented — mark support pending "
+                "(NOFUZZ cannot be applied to a gendef block)"
+            )
+            raise NoFuzzGenDefNotImplementedError(msg)
+
         lines: list[str] = []
 
         # Generic parameters are always present for gendef
@@ -555,17 +680,31 @@ class _ParagraphsCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
 
         Supports mixed content (multiple construct types in one block).
         """
-        lines: list[str] = []
+        lines: list[str] = [r"\begin{zed}"]
+        lines.extend(self._generate_zed_body(node.content))
+        lines.append(r"\end{zed}")
+        lines.append("")
+        return lines
 
-        lines.append(r"\begin{zed}")
+    def _generate_zed_body(self, content: Expr | Document) -> list[str]:
+        """Generate the inner lines of a zed block's body (no env wrapper).
+
+        ``Zed`` does not carry a ``nofuzz_reason`` (NOFUZZ only marks the
+        top-level box-producing nodes -- axdef/schema/gendef/given
+        type/free type/abbreviation -- not an explicit ``zed ... end``
+        block's internal items), so this always renders for the plain
+        ``zed`` environment.
+        """
+        block_kind = "zed"
+        lines: list[str] = []
 
         # All expression generation inside this block uses Z-paragraph context.
         prev_z = self._in_z_paragraph
         self._in_z_paragraph = True
         try:
             # Handle Document content (multiple items in zed block)
-            if isinstance(node.content, Document):
-                for idx, item in enumerate(node.content.items):
+            if isinstance(content, Document):
+                for idx, item in enumerate(content.items):
                     # Add \also separator before all items except the first
                     # Note: fuzz requires \also between Z paragraphs, not \\
                     if idx > 0:
@@ -578,7 +717,7 @@ class _ParagraphsCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
                         self._check_overflow(
                             given_line,
                             item.line,
-                            "zed given types",
+                            f"{block_kind} given types",
                         )
                         lines.append(given_line)
 
@@ -594,7 +733,7 @@ class _ParagraphsCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
                                     branch.parameters,
                                     branch.parameters.line,
                                     params_latex,
-                                    "zed",
+                                    block_kind,
                                 )
                                 branch_str = (
                                     f"{branch.name} \\ldata {params_latex} \\rdata"
@@ -605,7 +744,7 @@ class _ParagraphsCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
                         self._check_overflow(
                             free_type_line,
                             item.line,
-                            "zed free type",
+                            f"{block_kind} free type",
                             f"{item.name} ::= ...",
                         )
                         lines.append(free_type_line)
@@ -622,12 +761,12 @@ class _ParagraphsCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
                         else:
                             abbrev_line = f"{name_latex} == {expr_latex}"
                         self._reject_ra_in_box(
-                            item.expression, item.line, abbrev_line, "zed"
+                            item.expression, item.line, abbrev_line, block_kind
                         )
                         self._check_overflow(
                             abbrev_line,
                             item.line,
-                            "zed abbreviation",
+                            f"{block_kind} abbreviation",
                             f"{item.name} == ...",
                         )
                         lines.append(abbrev_line)
@@ -635,29 +774,26 @@ class _ParagraphsCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
                     # Generate expressions/predicates
                     elif isinstance(item, Expr):
                         content_latex = self.generate_expr(item)
-                        self._reject_ra_in_box(item, item.line, content_latex, "zed")
+                        self._reject_ra_in_box(
+                            item, item.line, content_latex, block_kind
+                        )
                         self._check_overflow(
                             content_latex,
                             item.line,
-                            "zed predicate",
+                            f"{block_kind} predicate",
                         )
                         lines.append(f"{content_latex}")
             else:
                 # Single expression (backward compatible)
-                content_latex = self.generate_expr(node.content)
-                self._reject_ra_in_box(
-                    node.content, node.content.line, content_latex, "zed"
-                )
+                content_latex = self.generate_expr(content)
+                self._reject_ra_in_box(content, content.line, content_latex, block_kind)
                 self._check_overflow(
                     content_latex,
-                    node.content.line,
-                    "zed predicate",
+                    content.line,
+                    f"{block_kind} predicate",
                 )
                 lines.append(f"{content_latex}")
         finally:
             self._in_z_paragraph = prev_z
-
-        lines.append(r"\end{zed}")
-        lines.append("")
 
         return lines

--- a/src/txt2tex/codegen/paragraphs.py
+++ b/src/txt2tex/codegen/paragraphs.py
@@ -166,7 +166,9 @@ class _ParagraphsCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
         ``_generate_given_type`` for the identical pattern.
         """
         lines: list[str] = []
-        block_kind = "zednofuzz" if node.nofuzz_reason is not None else "zed"
+        # Source-level kind for user-facing diagnostics; the emitted LaTeX
+        # environment (zed vs zednofuzz) is chosen separately below.
+        block_kind = "zed"
 
         # Generate each branch with proper LaTeX formatting
         branch_strs: list[str] = []
@@ -426,7 +428,9 @@ class _ParagraphsCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
             # Pure Z RHS — emit inside a zed paragraph for fuzz type-checking.
             # nofuzz_reason swaps the wrapper to zednofuzz and stages the
             # plain-zed probe for the CLI's reject-if-clean lint.
-            block_kind = "zednofuzz" if node.nofuzz_reason is not None else "zed"
+            # Source-level kind for user-facing diagnostics; the emitted LaTeX
+            # environment (zed vs zednofuzz) is chosen separately below.
+            block_kind = "zed"
             self._check_overflow(
                 abbrev,
                 node.line,
@@ -465,7 +469,9 @@ class _ParagraphsCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
         CLI's reject-if-clean lint -- the declaration/where-clause body
         itself renders identically either way.
         """
-        block_kind = "axdefnofuzz" if node.nofuzz_reason is not None else "axdef"
+        # Source-level kind for user-facing diagnostics; the emitted LaTeX
+        # environment (axdef vs axdefnofuzz) is chosen separately below.
+        block_kind = "axdef"
         body_lines: list[str] = []
 
         # All expression generation inside this block uses Z-paragraph context so

--- a/src/txt2tex/codegen/paragraphs.py
+++ b/src/txt2tex/codegen/paragraphs.py
@@ -380,6 +380,17 @@ class _ParagraphsCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
             )
             raise NoFuzzUnsupportedError(msg)
 
+        # Generic abbreviations are rejected under NOFUZZ for the same reason
+        # as generic axdef/schema: the twin environments do not render generic
+        # parameters yet.  Keep the rule uniform across box kinds (and matching
+        # the user guide) rather than silently accept it here.
+        if node.generic_params and node.nofuzz_reason is not None:
+            msg = (
+                "NOFUZZ does not support generic parameters yet — remove the "
+                "generic parameters or the NOFUZZ modifier."
+            )
+            raise NoFuzzUnsupportedError(msg)
+
         # Pick the wrapping based on RHS content
         if is_relational_rhs:
             # Dual-emit for binding set comprehensions: hidden copy with

--- a/src/txt2tex/codegen/paragraphs.py
+++ b/src/txt2tex/codegen/paragraphs.py
@@ -56,7 +56,19 @@ class NoFuzzLintItem:
     probe_snippet: str
 
 
-class NoFuzzGenDefNotImplementedError(Exception):
+class NoFuzzUnsupportedError(Exception):
+    """Raised when a NOFUZZ modifier cannot be honored with valid output.
+
+    Covers the cases that have no correct rendering: a box carrying generic
+    parameters (the twin environments take no generic argument yet) and
+    zed-cm (``--zed``) mode (the twin environments are undefined there, and
+    that mode performs no type-checking, so a waiver is meaningless).
+    Codegen rejects with an actionable message rather than emit broken
+    LaTeX.
+    """
+
+
+class NoFuzzGenDefNotImplementedError(NoFuzzUnsupportedError):
     """Raised when a NOFUZZ modifier marks a ``gendef``.
 
     No ``gendefnofuzz`` LaTeX environment exists yet (unlike
@@ -533,6 +545,13 @@ class _ParagraphsCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
             lines.append(r"\end{axdef}")
             lines.append("")
             return lines
+
+        if node.generic_params:
+            msg = (
+                "NOFUZZ does not support generic parameters yet — remove the "
+                "generic parameters or the NOFUZZ modifier."
+            )
+            raise NoFuzzUnsupportedError(msg)
 
         probe_snippet = "\n".join(
             [f"\\begin{{axdef}}{generics_suffix}", *body_lines, r"\end{axdef}"]

--- a/src/txt2tex/codegen/schemas.py
+++ b/src/txt2tex/codegen/schemas.py
@@ -205,7 +205,9 @@ class _SchemasCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
         identifiers like S+, S*, S~ (partial support, GitHub #3 still open).
         """
         lines: list[str] = []
-        block_kind = "schemanofuzz" if node.nofuzz_reason is not None else "schema"
+        # Source-level kind for user-facing diagnostics; the emitted LaTeX
+        # environment (schema vs schemanofuzz) is chosen separately below.
+        block_kind = "schema"
 
         # Determine schema name (empty string for anonymous)
         # Process name through _generate_identifier() for compound identifiers

--- a/src/txt2tex/codegen/schemas.py
+++ b/src/txt2tex/codegen/schemas.py
@@ -27,10 +27,15 @@ from txt2tex.ast_nodes import (
     SchemaText,
 )
 from txt2tex.codegen._dispatch import CodegenDispatch, expr_register, item_register
+from txt2tex.codegen.paragraphs import NoFuzzLintItem
 
 
 class _SchemasCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
     """Mixin: handlers for schema constructs."""
+
+    # Populated on LaTeXGenerator (see latex_gen.py __init__/_resolve_toc_depth);
+    # declared here so mypy/pyright resolve self.nofuzz_lint_items in this file.
+    nofuzz_lint_items: list[NoFuzzLintItem]
 
     @expr_register.register(SchemaText)
     def _generate_schema_text_expr(
@@ -189,12 +194,18 @@ class _SchemasCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
         For schemas with pk-marked fields, uses dual-emit: a fuzz-checked copy
         inside ``\\setbox0=\\vbox{%…}`` (invisible to LaTeX output) and a
         rendered copy using the ``schemapk`` environment with
-        ``\\underline{field}`` for each primary-key attribute.
+        ``\\underline{field}`` for each primary-key attribute.  A
+        ``nofuzz_reason`` schema skips that dual-emit entirely -- fuzz never
+        sees a ``schemanofuzz`` box, so there is no reason to keep an
+        invisible checked copy around -- and renders once, with PK
+        underlining if marked, staging a throwaway plain-``schema`` probe
+        (see ``NoFuzzLintItem``) for the CLI's reject-if-clean lint.
 
         Processes schema names through _generate_identifier() for compound
         identifiers like S+, S*, S~ (partial support, GitHub #3 still open).
         """
         lines: list[str] = []
+        block_kind = "schemanofuzz" if node.nofuzz_reason is not None else "schema"
 
         # Determine schema name (empty string for anonymous)
         # Process name through _generate_identifier() for compound identifiers
@@ -207,7 +218,9 @@ class _SchemasCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
             schema_name = ""
 
         # Context for overflow warnings
-        schema_context = f"schema {schema_name}" if schema_name else "anonymous schema"
+        schema_context = (
+            f"{block_kind} {schema_name}" if schema_name else f"anonymous {block_kind}"
+        )
 
         # Detect PK fields early so we know whether dual-emit is needed.
         pk_vars: set[str] = set()
@@ -238,7 +251,7 @@ class _SchemasCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
             if node.declarations:
                 for i, decl in enumerate(node.declarations):
                     if isinstance(decl, SchemaInclusion):
-                        decl_line = self._emit_schema_inclusion(decl, "schema")
+                        decl_line = self._emit_schema_inclusion(decl, block_kind)
                         plain_body.append(
                             f"{decl_line} \\\\"
                             if i < len(node.declarations) - 1
@@ -278,7 +291,7 @@ class _SchemasCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
                             decl.type_expr,
                             decl.type_expr.line,
                             plain_decl_line,
-                            "schema",
+                            block_kind,
                         )
                         self._check_overflow(
                             plain_decl_line,
@@ -305,7 +318,7 @@ class _SchemasCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
                 for group_idx, group in enumerate(node.predicates):
                     for pred_idx, pred in enumerate(group):
                         pred_latex = self.generate_expr(pred, parent=None)
-                        self._reject_ra_in_box(pred, pred.line, pred_latex, "schema")
+                        self._reject_ra_in_box(pred, pred.line, pred_latex, block_kind)
                         self._check_overflow(
                             pred_latex,
                             pred.line,
@@ -320,7 +333,36 @@ class _SchemasCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
         finally:
             self._in_z_paragraph = prev_z
 
-        if pk_vars:
+        if node.nofuzz_reason is not None:
+            # NOFUZZ: fuzz never sees this box, so render once -- with PK
+            # underlining if marked -- instead of the checked+rendered
+            # dual-emit a plain pk-marked schema needs.
+            probe_snippet = "\n".join(
+                [begin_schema, *plain_body, *where_lines, r"\end{schema}"]
+            )
+            self.nofuzz_lint_items.append(
+                NoFuzzLintItem(
+                    line=node.line,
+                    reason=node.nofuzz_reason,
+                    probe_snippet=probe_snippet,
+                )
+            )
+            escaped_reason = self._escape_latex_text(node.nofuzz_reason)
+            if node.generic_params:
+                params_str = ", ".join(node.generic_params)
+                begin_schemanofuzz = (
+                    f"\\begin{{schemanofuzz}}{{{schema_name}}}{{{escaped_reason}}}"
+                    f"[{params_str}]"
+                )
+            else:
+                begin_schemanofuzz = (
+                    f"\\begin{{schemanofuzz}}{{{schema_name}}}{{{escaped_reason}}}"
+                )
+            lines.append(begin_schemanofuzz)
+            lines.extend(pk_body if pk_vars else plain_body)
+            lines.extend(where_lines)
+            lines.append(r"\end{schemanofuzz}")
+        elif pk_vars:
             # Dual-emit: fuzz-checked copy inside \vbox (invisible), then
             # rendered schemapk copy with \underline on PK fields.
             # Must use \setbox0=\vbox, not \savebox — fuzz.sty's schema

--- a/src/txt2tex/codegen/schemas.py
+++ b/src/txt2tex/codegen/schemas.py
@@ -27,7 +27,7 @@ from txt2tex.ast_nodes import (
     SchemaText,
 )
 from txt2tex.codegen._dispatch import CodegenDispatch, expr_register, item_register
-from txt2tex.codegen.paragraphs import NoFuzzLintItem
+from txt2tex.codegen.paragraphs import NoFuzzLintItem, NoFuzzUnsupportedError
 
 
 class _SchemasCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
@@ -337,6 +337,12 @@ class _SchemasCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
             # NOFUZZ: fuzz never sees this box, so render once -- with PK
             # underlining if marked -- instead of the checked+rendered
             # dual-emit a plain pk-marked schema needs.
+            if node.generic_params:
+                msg = (
+                    "NOFUZZ does not support generic parameters yet — remove "
+                    "the generic parameters or the NOFUZZ modifier."
+                )
+                raise NoFuzzUnsupportedError(msg)
             probe_snippet = "\n".join(
                 [begin_schema, *plain_body, *where_lines, r"\end{schema}"]
             )
@@ -348,16 +354,9 @@ class _SchemasCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
                 )
             )
             escaped_reason = self._escape_latex_text(node.nofuzz_reason)
-            if node.generic_params:
-                params_str = ", ".join(node.generic_params)
-                begin_schemanofuzz = (
-                    f"\\begin{{schemanofuzz}}{{{schema_name}}}{{{escaped_reason}}}"
-                    f"[{params_str}]"
-                )
-            else:
-                begin_schemanofuzz = (
-                    f"\\begin{{schemanofuzz}}{{{schema_name}}}{{{escaped_reason}}}"
-                )
+            begin_schemanofuzz = (
+                f"\\begin{{schemanofuzz}}{{{schema_name}}}{{{escaped_reason}}}"
+            )
             lines.append(begin_schemanofuzz)
             lines.extend(pk_body if pk_vars else plain_body)
             lines.extend(where_lines)

--- a/src/txt2tex/latex/zednofuzz.sty
+++ b/src/txt2tex/latex/zednofuzz.sty
@@ -1,0 +1,156 @@
+%
+% zednofuzz.sty
+%
+% Companion package to fuzz.sty for txt2tex's NOFUZZ feature.
+%
+% PURPOSE
+%   Some genuine Z predicates cannot be parsed by the fuzz type-checker
+%   binary (e.g. `n = n^2`, which fuzz reads `^` as sequence iteration,
+%   not exponentiation). The *nofuzz twins defined here render such a
+%   paragraph -- using the same real box shapes fuzz.sty draws for the
+%   checked kind (rules, weight, indentation, skips are byte-identical)
+%   -- plus one mandatory note line below the box. There is no on-box
+%   mark and no separate "loud" frame: the checked and unchecked boxes
+%   of the same kind are visually identical, full stop -- only the
+%   note line distinguishes them. (An earlier revision offered a
+%   switchable on-box dagger in three placements; the student picked
+%   "note line only", so that machinery has been removed rather than
+%   left switched off.)
+%
+% WHY THE ENVIRONMENT NAMES MATTER
+%   `fuzz file.tex` is a static scanner over the .tex source text: it
+%   recognises the literal strings `\begin{zed}`, `\begin{axdef}`,
+%   `\begin{schema}`, `\begin{gendef}`, `\begin{syntax}` and type-checks
+%   what's inside. `zednofuzz`/`axdefnofuzz`/`schemanofuzz` are
+%   deliberately outside that set, so fuzz skips the blocks
+%   structurally -- it never sees the offending predicate and never has
+%   a chance to reject it. For that skip to hold, this file must NOT
+%   expand e.g. `\begin{axdefnofuzz}` into a real `\begin{axdef}`
+%   (fuzz's scanner would then find a nested `\begin{axdef}` and try to
+%   check it). Instead, each twin is built directly from the same
+%   low-level primitives its checked counterpart is built from --
+%   `\@zed`, `\@znoskip`, `\@zlign`, `\@jot`, `\@zskip`, `\@narrow`,
+%   `\@topline`-equivalent, `\@zedline` -- all defined in fuzz.sty and
+%   shared across zed/axdef/schema/argue/syntax/infrule. None of those
+%   primitives is environment-name specific, so reusing them carries no
+%   risk of fuzz seeing a checked delimiter.
+%
+% SHAPES (mirror the checked kind exactly; see fuzz.sty for the
+% originals -- \zed/\axdef/\schema)
+%   zednofuzz     -- bare: no frame at all (given sets, abbreviations,
+%                    free types render frameless, same as a real \zed).
+%   axdefnofuzz   -- continuous black left vertical rule (one per row,
+%                    via the row template, exactly like \axdef) plus
+%                    whatever `\where` separator bar the body invokes.
+%                    No top/bottom/right rule.
+%   schemanofuzz  -- axdef shape (left rule + \where bar) plus a top
+%                    rule carrying the schema NAME in a tab at the left
+%                    terminus (fuzz.sty's \@topline mechanism, reused
+%                    verbatim) and a full-width solid bottom rule
+%                    (fuzz.sty's \@zedline, reused verbatim). Right
+%                    side stays open, same as a real \schema.
+%   gendefnofuzz  -- NOT built yet (deferred). fuzz.sty's real \gendef
+%                    draws a bracketed generic-parameter tab at the top
+%                    (`\@gendef`/`\@ngendef`, using \doublerulesep for
+%                    the double top rule) instead of schema's name tab.
+%                    When this twin is needed: reuse `\@gendef`'s
+%                    `\@topline`-style bracket line the same way
+%                    `\@nftopline` below reuses schema's, keep the
+%                    axdef row template (left rule + \where bar), close
+%                    with `\@zedline` (as schemanofuzz does), and route
+%                    the reason through `\@nfreason` like the other
+%                    three. Two args: `{generic params}{reason}`,
+%                    mirroring schemanofuzz's `{name}{reason}`.
+%
+% NOTE LINE (the only mark -- mandatory, not suppressible)
+%   Every twin renders, immediately below the box (no paragraph break,
+%   indented to \zedindent so its left edge lines up with the box):
+%       † not type-checked --- <reason>
+%   in \footnotesize italics. "not type-checked" is a fixed constant;
+%   only the text after the em-dash comes from the environment's #1
+%   (or #2 for schemanofuzz, whose #1 is the schema name). There is no
+%   package option or flag that suppresses \@nfreason.
+%
+% REQUIRES
+%   fuzz.sty, loaded first, for \zedindent/\zedleftsep/\zedskip/\zedbar/
+%   \@jot/\preboxpenalty and the \@zed/\@znoskip/\@zlign/\@zskip/
+%   \@narrow/\@zedline/\t/\also machinery. \dagger is a base LaTeX math
+%   symbol (OMS/symbols font) -- no extra package needed for it.
+%
+
+\ProvidesPackage{zednofuzz}[2026/07/04]
+
+\RequirePackage{fuzz}
+
+% \@nftopline#1 -- schemanofuzz's top rule: byte-for-byte fuzz.sty's
+% \@topline (corner mark, zedleftsep gap, name, rule-fill to the right
+% edge). No on-box mark spliced in -- the note line below the box is
+% the only indicator that this twin isn't type-checked.
+\def\@nftopline#1{\hbox to\linewidth{%
+  \vrule height\arrayrulewidth width\arrayrulewidth
+  \vrule height0pt depth\@jot width0pt
+  \hbox to\zedleftsep{\@zrulefill\thinspace}%
+  #1\thinspace\@zrulefill}}
+
+% \@nfreason#1 -- the mandatory note line. Fixed phrase "not
+% type-checked" plus the reason argument; \footnotesize italic;
+% directly below the box (no \par before it, so no blank line is
+% inserted between the box and the note), indented to \zedindent so
+% its left edge lines up with the box above it. Not gated by any
+% option or flag -- always renders.
+\def\@nfreason#1{%
+  \par\noindent\hskip\zedindent
+  {\footnotesize\itshape$\dagger$\ not type-checked --- #1\par}}
+
+% axdefnofuzz{<reason>} -- axdef shape: continuous left rule (row
+% template, below) + whatever \where bar the body invokes. Body syntax
+% (identifiers, \t1/\t2, \also, \where, \\) is identical to \axdef's;
+% compare to fuzz.sty's \def\axdef{...}. Byte-identical to a checked
+% \axdef box -- the note line below is the only difference.
+\newenvironment{axdefnofuzz}[1]{%
+  \def\@currnfreason{#1}%
+  \def\also{\@zskip\zedskip}%
+  \predisplaypenalty=\preboxpenalty
+  \@zed\@znoskip \halign to\linewidth\bgroup
+    \strut \vrule width\arrayrulewidth \hskip\zedleftsep
+    $\@zlign##$\hfil \tabskip=0pt plus1fil\cr
+}{%
+  \crcr\egroup$$\global\@ignoretrue
+  \@nfreason{\@currnfreason}%
+}
+
+% zednofuzz{<reason>} -- bare shape: no left rule, no top/bottom rule.
+% Compare to fuzz.sty's \def\zed{...}. Byte-identical to a checked
+% \zed box -- the note line below is the only difference.
+\newenvironment{zednofuzz}[1]{%
+  \def\@currnfreason{#1}%
+  \@zed\@znoskip
+  \halign to\linewidth\bgroup
+    \strut$\@zlign##$\hfil \tabskip=0pt plus1fil\cr
+}{%
+  \crcr\egroup$$\global\@ignoretrue
+  \@nfreason{\@currnfreason}%
+}
+
+% schemanofuzz{<name>}{<reason>} -- schema shape: axdef's left rule +
+% \where bar, a top rule carrying the name (via \@nftopline above),
+% and a full-width solid bottom rule (fuzz.sty's own \@zedline, reused
+% verbatim -- it's already environment-name agnostic). Right side
+% stays open. Compare to fuzz.sty's \def\@nschema / \def\endschema.
+% Byte-identical to a checked \schema box -- the note line below is
+% the only difference.
+\newenvironment{schemanofuzz}[2]{%
+  \def\@currnfname{#1}%
+  \def\@currnfreason{#2}%
+  \@narrow
+  \def\also{\@zskip\zedskip}%
+  \predisplaypenalty=\preboxpenalty
+  \@zed\@znoskip \halign to\linewidth\bgroup
+    \strut \vrule width\arrayrulewidth \hskip\zedleftsep
+    $\@zlign##$\hfil \tabskip=0pt plus1fil\cr
+  \omit\@nftopline{$\strut\@currnfname$}\cr
+}{%
+  \@zskip\@jot \@zedline
+  \crcr\egroup$$\global\@ignoretrue
+  \@nfreason{\@currnfreason}%
+}

--- a/src/txt2tex/latex/zednofuzz.sty
+++ b/src/txt2tex/latex/zednofuzz.sty
@@ -94,10 +94,11 @@
 
 % \@nfreason#1 -- the mandatory note line. Fixed phrase "not
 % type-checked" plus the reason argument; \footnotesize italic;
-% directly below the box (no \par before it, so no blank line is
-% inserted between the box and the note), indented to \zedindent so
-% its left edge lines up with the box above it. Not gated by any
-% option or flag -- always renders.
+% directly below the box. The leading \par ends the box's display and
+% starts the note on the next line without adding vertical space, so
+% no blank line appears between the box and the note. Indented to
+% \zedindent so its left edge lines up with the box above it. Not
+% gated by any option or flag -- always renders.
 \def\@nfreason#1{%
   \par\noindent\hskip\zedindent
   {\footnotesize\itshape$\dagger$\ not type-checked --- #1\par}}

--- a/src/txt2tex/latex_gen.py
+++ b/src/txt2tex/latex_gen.py
@@ -10,6 +10,7 @@ from typing import ClassVar
 from txt2tex.__version__ import __version__
 from txt2tex.ast_nodes import (
     Abbreviation,
+    AxDef,
     BinaryOp,
     Conditional,
     Contents,
@@ -20,6 +21,7 @@ from txt2tex.ast_nodes import (
     ExtendAggregate,
     FreeType,
     FunctionApp,
+    GenDef,
     GenericInstantiation,
     GivenType,
     Group,
@@ -33,6 +35,7 @@ from txt2tex.ast_nodes import (
     RelationalImage,
     RelationRename,
     Restrict,
+    Schema,
     Section,
     SequenceLiteral,
     SetComprehension,
@@ -67,6 +70,7 @@ from txt2tex.codegen.overflow import (
 )
 from txt2tex.codegen.paragraphs import (
     NoFuzzLintItem,
+    NoFuzzUnsupportedError,
     _ParagraphsCodegen,  # pyright: ignore[reportPrivateUsage]
 )
 from txt2tex.codegen.paren_policy import (
@@ -314,6 +318,27 @@ class LaTeXGenerator(
                 yield from self._iter_items_in_document_order(item.items)
             elif isinstance(item, Zed) and isinstance(item.content, Document):
                 yield from self._iter_items_in_document_order(item.content.items)
+
+    def _reject_nofuzz_in_zed_mode(self, items: list[DocumentItem]) -> None:
+        """Reject a NOFUZZ modifier when generating in zed-cm (``--zed``) mode.
+
+        The twin environments (``axdefnofuzz``/``zednofuzz``/``schemanofuzz``)
+        are only loaded in fuzz mode and are built on fuzz.sty primitives,
+        so emitting one under ``--zed`` yields an undefined environment.
+        zed-cm mode also runs no type-checker, so a waiver is meaningless.
+        Reject with an actionable message instead of shipping broken LaTeX.
+        """
+        if self.use_fuzz:
+            return
+        nofuzz_kinds = (AxDef, Schema, GenDef, GivenType, FreeType, Abbreviation)
+        for item in self._iter_items_in_document_order(items):
+            if isinstance(item, nofuzz_kinds) and item.nofuzz_reason is not None:
+                msg = (
+                    "NOFUZZ is a fuzz-mode feature and is not supported with "
+                    "--zed; zed-cm mode performs no type-checking, so there is "
+                    "nothing to waive."
+                )
+                raise NoFuzzUnsupportedError(msg)
 
     def _collect_declared_and_tainted_names(self, items: list[DocumentItem]) -> None:
         """Populate ``_fuzz_declared_names`` and ``_ra_tainted_names`` up front.
@@ -571,6 +596,7 @@ class LaTeXGenerator(
         """
         # Store document-level parts format
         self.parts_format = ast.parts_format
+        self._reject_nofuzz_in_zed_mode(ast.items)
         self._resolve_toc_depth(ast.items)
 
         # Generate all document items
@@ -676,6 +702,7 @@ class LaTeXGenerator(
         if isinstance(ast, Document):
             # Store document-level parts format
             self.parts_format = ast.parts_format
+            self._reject_nofuzz_in_zed_mode(ast.items)
             self._resolve_toc_depth(ast.items)
             # Multi-line document: generate each item
             # Consolidate consecutive zed environments

--- a/src/txt2tex/latex_gen.py
+++ b/src/txt2tex/latex_gen.py
@@ -66,6 +66,7 @@ from txt2tex.codegen.overflow import (
     _OverflowCodegen,  # pyright: ignore[reportPrivateUsage]
 )
 from txt2tex.codegen.paragraphs import (
+    NoFuzzLintItem,
     _ParagraphsCodegen,  # pyright: ignore[reportPrivateUsage]
 )
 from txt2tex.codegen.paren_policy import (
@@ -180,6 +181,7 @@ class LaTeXGenerator(
     _in_hidden_fuzz_block: bool
     _ra_tainted_names: set[str]
     _fuzz_declared_names: set[str]
+    nofuzz_lint_items: list[NoFuzzLintItem]
 
     def __init__(
         self,
@@ -238,6 +240,11 @@ class LaTeXGenerator(
         # to keep such names inside a fuzz-checked zed block. See
         # _is_ra_tainted.
         self._fuzz_declared_names = set()
+        # NOFUZZ-marked boxes encountered during generation, staged for the
+        # CLI's reject-if-clean lint (see NoFuzzLintItem and the
+        # nofuzz_reason handling in _generate_given_type/_generate_free_type/
+        # _generate_abbreviation/_generate_axdef/_generate_schema).
+        self.nofuzz_lint_items = []
 
     def _next_synth_name(self) -> str:
         """Generate the next synthetic abbreviation name for fuzz validation."""
@@ -282,6 +289,9 @@ class LaTeXGenerator(
         self._ra_tainted_names = set()
         self._fuzz_declared_names = set()
         self._collect_declared_and_tainted_names(items)
+        # Reset NOFUZZ lint staging so a reused generator (REPL) does not
+        # leak blocks from a previous, unrelated document.
+        self.nofuzz_lint_items = []
 
     def _iter_items_in_document_order(
         self, items: list[DocumentItem]
@@ -414,22 +424,36 @@ class LaTeXGenerator(
         """Generate document items with zed environment consolidation.
 
         Groups consecutive GivenType, FreeType, and Abbreviation items
-        into a single zed environment with \\also between them.
+        into a single zed environment with \\also between them.  A
+        NOFUZZ-marked item (``nofuzz_reason is not None``) never joins a
+        consolidated run -- it renders alone, in its own ``zednofuzz`` box
+        (see ``_generate_given_type``/``_generate_free_type``/
+        ``_generate_abbreviation``), so a checked run before or after it
+        still consolidates normally.
         """
         lines: list[str] = []
         i = 0
         while i < len(items):
             item = items[i]
             # Check if this is a zed-generating item
-            if isinstance(item, (GivenType, FreeType, Abbreviation)) and not (
-                isinstance(item, Abbreviation) and self._is_ra_tainted(item.expression)
+            if (
+                isinstance(item, (GivenType, FreeType, Abbreviation))
+                and item.nofuzz_reason is None
+                and not (
+                    isinstance(item, Abbreviation)
+                    and self._is_ra_tainted(item.expression)
+                )
             ):
-                # Collect consecutive zed items (exclude RA-tainted abbreviations)
+                # Collect consecutive zed items (exclude RA-tainted
+                # abbreviations and NOFUZZ-marked items -- either one
+                # breaks the run).
                 zed_items: list[GivenType | FreeType | Abbreviation] = [item]
                 j = i + 1
                 while j < len(items):
                     next_item = items[j]
                     if not isinstance(next_item, (GivenType, FreeType, Abbreviation)):
+                        break
+                    if next_item.nofuzz_reason is not None:
                         break
                     if isinstance(next_item, Abbreviation) and self._is_ra_tainted(
                         next_item.expression
@@ -589,6 +613,16 @@ class LaTeXGenerator(
         )
         if self.use_fuzz:
             lines.append(r"\usepackage{fuzz}")  # Replaces zed-cm (fonts/styling)
+            # NOFUZZ: provides axdefnofuzz/zednofuzz/schemanofuzz, twins of
+            # axdef/zed/schema for Z the fuzz type-checker can't parse (e.g.
+            # n = n^2). Each twin is byte-identical in shape to its checked
+            # counterpart -- no on-box mark -- plus a mandatory
+            # "not type-checked" note line below the box; see zednofuzz.sty
+            # for why the env names (not "axdef"/"zed"/"schema") keep fuzz's
+            # structural scanner from descending into them. Fuzz-mode only:
+            # the fuzz binary is only invoked when not args.zed (see
+            # cli.py), so zed-cm mode has no need of it.
+            lines.append(r"\usepackage{zednofuzz}")
         else:
             lines.append(r"\usepackage{zed-cm}")  # Computer Modern fonts/styling
         lines.append(r"\usepackage{schemapk}")  # schemapk env for PK underlines

--- a/src/txt2tex/latex_gen.py
+++ b/src/txt2tex/latex_gen.py
@@ -364,7 +364,19 @@ class LaTeXGenerator(
         ``len(abbreviations)`` — each pass either grows the (finite) tainted
         set or the loop stops.
         """
+        nofuzz_declaring_kinds = (GivenType, FreeType, AxDef, GenDef, Schema)
         for item in self._iter_items_in_document_order(items):
+            if (
+                isinstance(item, nofuzz_declaring_kinds)
+                and item.nofuzz_reason is not None
+            ):
+                # A NOFUZZ box is skipped by fuzz's scanner, so the names it
+                # introduces are invisible to the type-checker.  They must not
+                # count as fuzz-declared -- otherwise a later RA reference to
+                # one would be wrongly un-tainted (the "axdef bridge" only
+                # holds for names fuzz actually sees), or a checked box would
+                # appear to have a declaration fuzz never receives.
+                continue
             self._fuzz_declared_names |= self._collect_fuzz_declared_names(item)
 
         abbreviations = [

--- a/src/txt2tex/lexer.py
+++ b/src/txt2tex/lexer.py
@@ -193,6 +193,7 @@ RESERVED_WORDS: frozenset[str] = frozenset(
         "BIBLIOGRAPHY_STYLE",
         "PAGEBREAK",
         "LINEBREAK",
+        "NOFUZZ",
     }
 )
 
@@ -1391,6 +1392,38 @@ class Lexer:
                     start_column,
                 )
             return Token(TokenType.B_BLOCK, body, start_line, start_column)
+
+        # Check for NOFUZZ: keyword — a one-line modifier marking the
+        # immediately-following box paragraph (axdef/schema/gendef/given
+        # type/free type/abbreviation) as genuine Z the fuzz type checker
+        # cannot parse (e.g. `n = n^2`, where fuzz reads `^` as relation
+        # iteration).  The reason (rest of the line) is *mandatory* — an
+        # undocumented waiver is a lex error, not a silent no-op.  Unlike
+        # B:/LATEX:, there is no slurped body: the parser parses the next
+        # box paragraph through its normal grammar (see
+        # _parse_nofuzz_modifier) and stamps the reason onto that node.
+        if value == "NOFUZZ" and self._current_char() == ":":
+            self._advance()  # Consume ':'
+
+            # Skip whitespace after the colon.
+            while not self._at_end() and self._current_char() in " \t":
+                self._advance()
+
+            # Capture the reason: the rest of the header line.
+            reason_start = self.pos
+            while not self._at_end() and self._current_char() != "\n":
+                self._advance()
+            reason = self.text[reason_start : self.pos].strip()
+            if not reason:
+                raise LexerError(
+                    f"NOFUZZ: at line {start_line} has no reason — state why "
+                    f"fuzz cannot check this content, e.g. "
+                    f"'NOFUZZ: fuzz reads ^ as relation iteration'",
+                    start_line,
+                    start_column,
+                )
+
+            return Token(TokenType.NOFUZZ, reason, start_line, start_column)
 
         # Auto-detect prose paragraphs BEFORE keyword checks
         # Also detect prose after part labels (any column)

--- a/src/txt2tex/lexer.py
+++ b/src/txt2tex/lexer.py
@@ -1418,7 +1418,7 @@ class Lexer:
                 raise LexerError(
                     f"NOFUZZ: at line {start_line} has no reason — state why "
                     f"fuzz cannot check this content, e.g. "
-                    f"'NOFUZZ: fuzz reads ^ as relation iteration'",
+                    f"'NOFUZZ: fuzz reads ^ as relational iteration'",
                     start_line,
                     start_column,
                 )

--- a/src/txt2tex/parser.py
+++ b/src/txt2tex/parser.py
@@ -904,6 +904,10 @@ class Parser(
             )
             raise ParserError(msg, tok)
 
+        if self._current().type == TokenType.NOFUZZ:
+            msg = "NOFUZZ cannot be applied twice to the same box"
+            raise ParserError(msg, tok)
+
         item = self._parse_document_item()
         if isinstance(item, AxDef):
             return dataclasses.replace(item, nofuzz_reason=reason)

--- a/src/txt2tex/parser.py
+++ b/src/txt2tex/parser.py
@@ -2,13 +2,20 @@
 
 from __future__ import annotations
 
+import dataclasses
 from typing import ClassVar
 
 from txt2tex.ast_nodes import (
+    Abbreviation,
+    AxDef,
     Declaration,
     Document,
     DocumentItem,
     Expr,
+    FreeType,
+    GenDef,
+    GivenType,
+    Schema,
     SchemaInclusion,
     TitleMetadata,
 )
@@ -451,6 +458,7 @@ class Parser(
             TokenType.AXDEF,
             TokenType.GENDEF,
             TokenType.ZED,
+            TokenType.NOFUZZ,
             TokenType.SCHEMA,
             TokenType.SYNTAX,
             TokenType.PROOF,
@@ -480,6 +488,8 @@ class Parser(
             return self._parse_gendef()
         if self._match(TokenType.ZED):
             return self._parse_zed()
+        if self._match(TokenType.NOFUZZ):
+            return self._parse_nofuzz_modifier()
         if self._match(TokenType.SCHEMA):
             return self._parse_schema()
         if self._match(TokenType.SYNTAX):
@@ -861,3 +871,56 @@ class Parser(
                 depth -= 1
             offset += 1
         return self._peek_ahead(offset).type == TokenType.DEFS
+
+    def _parse_nofuzz_modifier(self) -> DocumentItem:
+        """Parse a NOFUZZ: <reason> modifier onto the next box paragraph.
+
+        ``NOFUZZ:`` is a one-line prefix (the lexer already validated the
+        reason is non-empty) -- not a block of its own.  The immediately
+        following construct is parsed through its ordinary grammar
+        (``_parse_axdef``, ``_parse_given_type``, ...) via the normal
+        ``_parse_document_item`` dispatch, then re-stamped with
+        ``nofuzz_reason`` via ``dataclasses.replace``.  This makes NOFUZZ
+        content accept exactly what the equivalent checked box accepts,
+        with identical downstream rendering except for the wrapper.
+
+        The per-type ``isinstance`` branches below are also the allow-list:
+        GivenType/FreeType/Abbreviation are the "zed-producing" items that
+        consolidate into a `zed` box; AxDef/Schema/GenDef are boxes in
+        their own right.  Anything else (prose, a bare predicate, a proof
+        tree, ...) is inline/non-boxed content NOFUZZ cannot waive, and
+        falls through to the error.  (Each branch calls ``dataclasses.replace``
+        on a concretely-typed local rather than the ``DocumentItem`` union
+        so mypy can validate the ``nofuzz_reason`` keyword.)
+        """
+        tok = self._advance()  # Consume NOFUZZ token
+        reason = tok.value  # already validated non-empty by the lexer
+        self._skip_newlines()  # NOFUZZ: <reason> is a header line of its own
+
+        if self._at_end():
+            msg = (
+                "NOFUZZ: must be immediately followed by an axdef, schema, "
+                "gendef, given type, free type, or abbreviation"
+            )
+            raise ParserError(msg, tok)
+
+        item = self._parse_document_item()
+        if isinstance(item, AxDef):
+            return dataclasses.replace(item, nofuzz_reason=reason)
+        if isinstance(item, Schema):
+            return dataclasses.replace(item, nofuzz_reason=reason)
+        if isinstance(item, GenDef):
+            return dataclasses.replace(item, nofuzz_reason=reason)
+        if isinstance(item, GivenType):
+            return dataclasses.replace(item, nofuzz_reason=reason)
+        if isinstance(item, FreeType):
+            return dataclasses.replace(item, nofuzz_reason=reason)
+        if isinstance(item, Abbreviation):
+            return dataclasses.replace(item, nofuzz_reason=reason)
+
+        msg = (
+            f"NOFUZZ: must be immediately followed by an axdef, schema, "
+            f"gendef, given type, free type, or abbreviation, not "
+            f"{type(item).__name__}"
+        )
+        raise ParserError(msg, tok)

--- a/src/txt2tex/tokens.py
+++ b/src/txt2tex/tokens.py
@@ -146,6 +146,7 @@ class TokenType(Enum):
     PARTS = auto()  # PARTS: (parts formatting style)
     B_BLOCK = auto()  # B: (B-machine verbatim block, terminated by column-0 END)
     RAW_LATEX_BLOCK = auto()  # LATEX:\n...END (multi-line raw LaTeX, col-0 END)
+    NOFUZZ = auto()  # NOFUZZ: reason (one-line modifier on next box paragraph)
     BIBLIOGRAPHY = auto()  # BIBLIOGRAPHY: (bibliography file)
     BIBLIOGRAPHY_STYLE = auto()  # BIBLIOGRAPHY_STYLE: (bibliography style)
     # Title metadata

--- a/tests/test_nofuzz_block.py
+++ b/tests/test_nofuzz_block.py
@@ -539,3 +539,26 @@ def test_nofuzz_on_relational_algebra_abbreviation_raises() -> None:
     with pytest.raises(NoFuzzUnsupportedError) as exc_info:
         LaTeXGenerator(use_fuzz=True).generate_document(doc)
     assert "relational-algebra" in str(exc_info.value)
+
+
+def test_nofuzz_declared_names_are_not_fuzz_visible() -> None:
+    """A name declared in a NOFUZZ box must not enter _fuzz_declared_names.
+
+    The *nofuzz environment is skipped by fuzz's scanner, so its declared
+    names are invisible to the type-checker; treating them as fuzz-declared
+    would wrongly un-taint later RA references or make a checked box look as
+    if fuzz had seen the declaration. The identical checked axdef DOES declare
+    the name -- the contrast is the whole point.
+    """
+    nofuzz_src = (
+        "NOFUZZ: fuzz reads ^ as iteration\n"
+        "axdef\n  square : N -> N\nwhere\n  forall n : N | square(n) = n^2\nend\n"
+    )
+    gen = LaTeXGenerator(use_fuzz=True)
+    gen.generate_document(_parse(nofuzz_src))
+    assert "square" not in gen._fuzz_declared_names
+
+    checked_src = "axdef\n  square : N -> N\nwhere\n  square(0) = 0\nend\n"
+    checked_gen = LaTeXGenerator(use_fuzz=True)
+    checked_gen.generate_document(_parse(checked_src))
+    assert "square" in checked_gen._fuzz_declared_names

--- a/tests/test_nofuzz_block.py
+++ b/tests/test_nofuzz_block.py
@@ -529,3 +529,13 @@ def test_consecutive_nofuzz_raises_parser_error() -> None:
     with pytest.raises(ParserError) as exc_info:
         _lex_and_parse(source)
     assert "twice" in str(exc_info.value)
+
+
+def test_nofuzz_on_relational_algebra_abbreviation_raises() -> None:
+    """RA abbreviations render as display math outside any box; fuzz never
+    checks them, so a NOFUZZ waiver has nothing to waive -- reject rather
+    than silently drop the note (the RA branch used to ignore the modifier)."""
+    doc = _parse("NOFUZZ: fuzz reads ^ as iteration\nR == S join T\n")
+    with pytest.raises(NoFuzzUnsupportedError) as exc_info:
+        LaTeXGenerator(use_fuzz=True).generate_document(doc)
+    assert "relational-algebra" in str(exc_info.value)

--- a/tests/test_nofuzz_block.py
+++ b/tests/test_nofuzz_block.py
@@ -12,6 +12,7 @@ waiver).
 
 from __future__ import annotations
 
+import dataclasses
 import shutil
 import sys
 from pathlib import Path
@@ -29,7 +30,11 @@ from txt2tex.ast_nodes import (
     Schema,
 )
 from txt2tex.cli import lint_nofuzz_block, main
-from txt2tex.codegen.paragraphs import NoFuzzGenDefNotImplementedError, NoFuzzLintItem
+from txt2tex.codegen.paragraphs import (
+    NoFuzzGenDefNotImplementedError,
+    NoFuzzLintItem,
+    NoFuzzUnsupportedError,
+)
 from txt2tex.latex_gen import LaTeXGenerator
 from txt2tex.lexer import Lexer, LexerError
 from txt2tex.parser import Parser, ParserError
@@ -79,10 +84,10 @@ def test_whitespace_only_reason_raises_lexer_error():
 
 def test_reason_is_rest_of_header_line():
     """The reason is captured verbatim to end of line -- no END, no body slurp."""
-    tokens = Lexer("NOFUZZ: fuzz reads ^ as relation iteration\ngiven A\n").tokenize()
+    tokens = Lexer("NOFUZZ: fuzz reads ^ as relational iteration\ngiven A\n").tokenize()
     nofuzz_tokens = [t for t in tokens if t.type.name == "NOFUZZ"]
     assert len(nofuzz_tokens) == 1
-    assert nofuzz_tokens[0].value == "fuzz reads ^ as relation iteration"
+    assert nofuzz_tokens[0].value == "fuzz reads ^ as relational iteration"
 
 
 # ---------------------------------------------------------------------------
@@ -469,3 +474,58 @@ def test_cli_nofuzz_lint_skipped_when_fuzz_not_installed(
     assert result == 0
     captured = capsys.readouterr()
     assert "Skipping NOFUZZ lint" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Rejections: unsupported NOFUZZ targets (generics, --zed, stacked modifiers)
+# ---------------------------------------------------------------------------
+
+
+def test_nofuzz_schema_with_generics_raises() -> None:
+    """A generic schema cannot be a NOFUZZ twin -- the env takes no generics."""
+    doc = _parse("NOFUZZ: r\nschema S[X]\n  x : X\nwhere\n  x = x\nend\n")
+    with pytest.raises(NoFuzzUnsupportedError) as exc_info:
+        LaTeXGenerator(use_fuzz=True).generate_document(doc)
+    assert "generic parameters" in str(exc_info.value)
+
+
+def test_nofuzz_axdef_with_generics_raises() -> None:
+    """A generic axdef cannot be a NOFUZZ twin -- the env takes no generics."""
+    doc = _parse("NOFUZZ: r\naxdef\n  n : N\nwhere\n  n = n\nend\n")
+    axdef = doc.items[0]
+    assert isinstance(axdef, AxDef)
+    doc.items[0] = dataclasses.replace(axdef, generic_params=["X"])
+    with pytest.raises(NoFuzzUnsupportedError) as exc_info:
+        LaTeXGenerator(use_fuzz=True).generate_document(doc)
+    assert "generic parameters" in str(exc_info.value)
+
+
+def test_nofuzz_in_zed_mode_raises() -> None:
+    """NOFUZZ has no meaning and no defined env in zed-cm (--zed) mode."""
+    doc = _parse("NOFUZZ: fuzz reads ^ as iteration\ngiven A\n")
+    with pytest.raises(NoFuzzUnsupportedError) as exc_info:
+        LaTeXGenerator(use_fuzz=False).generate_document(doc)
+    assert "--zed" in str(exc_info.value)
+
+
+def test_cli_nofuzz_zed_mode_error_surfaces_cleanly(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """--zed + NOFUZZ is one clean error, not an undefined-env LaTeX crash."""
+    input_file = tmp_path / "zed_nofuzz.txt"
+    input_file.write_text("NOFUZZ: fuzz reads ^ as iteration\ngiven A\n")
+    with patch.object(sys, "argv", ["txt2tex", str(input_file), "--zed", "--tex-only"]):
+        result = main()
+    assert result == 1
+    captured = capsys.readouterr()
+    assert "Error:" in captured.err
+    assert "--zed" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_consecutive_nofuzz_raises_parser_error() -> None:
+    """Stacking NOFUZZ: on NOFUZZ: is rejected, not silently collapsed."""
+    source = "NOFUZZ: a\nNOFUZZ: b\naxdef\n  n : N\nwhere\n  n = n\nend\n"
+    with pytest.raises(ParserError) as exc_info:
+        _lex_and_parse(source)
+    assert "twice" in str(exc_info.value)

--- a/tests/test_nofuzz_block.py
+++ b/tests/test_nofuzz_block.py
@@ -523,6 +523,16 @@ def test_nofuzz_axdef_with_generics_raises() -> None:
     assert "generic parameters" in str(exc_info.value)
 
 
+def test_nofuzz_abbreviation_with_generics_raises() -> None:
+    """A generic abbreviation ([X] foo == ...) is rejected under NOFUZZ too,
+    uniformly with axdef/schema and the user guide -- the abbreviation path
+    used to emit the zednofuzz wrapper regardless."""
+    doc = _parse("NOFUZZ: fuzz reads ^ as iteration\n[X] foo == { x : X | true }\n")
+    with pytest.raises(NoFuzzUnsupportedError) as exc_info:
+        LaTeXGenerator(use_fuzz=True).generate_document(doc)
+    assert "generic parameters" in str(exc_info.value)
+
+
 def test_nofuzz_in_zed_mode_raises() -> None:
     """NOFUZZ has no meaning and no defined env in zed-cm (--zed) mode."""
     doc = _parse("NOFUZZ: fuzz reads ^ as iteration\ngiven A\n")

--- a/tests/test_nofuzz_block.py
+++ b/tests/test_nofuzz_block.py
@@ -390,7 +390,30 @@ def test_cli_build_fails_when_nofuzz_content_is_clean(
         result = main()
     assert result == 1
     captured = capsys.readouterr()
-    assert "type-checks cleanly under fuzz" in captured.err
+    assert "type-checks cleanly" in captured.err
+    assert "use a plain box instead" in captured.err
+
+
+@pytest.mark.skipif(not _fuzz_available(), reason="fuzz binary not installed")
+def test_cli_build_fails_when_nofuzz_probe_fails_only_on_undeclared_names(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A mislabeled waiver whose isolated probe fails only on undeclared names
+    (checkable once the earlier given is in scope) must still be rejected —
+    an undeclared-name failure is not genuine unparseability."""
+    input_file = tmp_path / "context_nofuzz.txt"
+    # `foo` is fully checkable given `T`; the probe omits `given T`, so fuzz
+    # fails only with "Identifier T is not declared". This is a mislabel.
+    input_file.write_text(
+        "given T\n\n"
+        "NOFUZZ: mislabeled — this is checkable once T is in scope\n"
+        "axdef\n  foo : T -> T\nwhere\n  forall x : T | foo(x) = x\nend\n"
+    )
+    with patch.object(sys, "argv", ["txt2tex", str(input_file), "--tex-only"]):
+        result = main()
+    assert result == 1
+    captured = capsys.readouterr()
+    assert "declared elsewhere" in captured.err
     assert "use a plain box instead" in captured.err
 
 

--- a/tests/test_nofuzz_block.py
+++ b/tests/test_nofuzz_block.py
@@ -1,0 +1,471 @@
+"""Tests for the NOFUZZ modifier: a one-line prefix marking the immediately
+following box paragraph (axdef/schema/gendef/given type/free type/
+abbreviation) as genuine Z that renders but is not fuzz-type-checked.
+
+Covers lexing (mandatory reason, no slurped body), parsing (the marked
+node's own grammar, unchanged, plus ``nofuzz_reason`` stamped on it via
+``dataclasses.replace``), codegen (the ``*nofuzz`` twin per box kind,
+reason escaping, zed consolidation-break), and the CLI reject-if-clean
+lint (a NOFUZZ box that type-checks cleanly on its own is a mislabeled
+waiver).
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from txt2tex.ast_nodes import (
+    Abbreviation,
+    AxDef,
+    Document,
+    FreeType,
+    GenDef,
+    GivenType,
+    Schema,
+)
+from txt2tex.cli import lint_nofuzz_block, main
+from txt2tex.codegen.paragraphs import NoFuzzGenDefNotImplementedError, NoFuzzLintItem
+from txt2tex.latex_gen import LaTeXGenerator
+from txt2tex.lexer import Lexer, LexerError
+from txt2tex.parser import Parser, ParserError
+
+
+def _fuzz_available() -> bool:
+    """Return True when the fuzz binary is on PATH."""
+    return shutil.which("fuzz") is not None
+
+
+def _parse(source: str) -> Document:
+    tokens = Lexer(source).tokenize()
+    ast = Parser(tokens).parse()
+    assert isinstance(ast, Document)
+    return ast
+
+
+def _lex_and_parse(source: str) -> Document | object:
+    """Lex and parse in one call, for use as pytest.raises' single statement."""
+    return Parser(Lexer(source).tokenize()).parse()
+
+
+def _parse_and_generate(source: str) -> str:
+    ast = _parse(source)
+    return LaTeXGenerator(use_fuzz=True).generate_document(ast)
+
+
+# ---------------------------------------------------------------------------
+# Lexer: mandatory reason, one-line modifier (no slurped body)
+# ---------------------------------------------------------------------------
+
+
+def test_missing_reason_raises_lexer_error():
+    """A NOFUZZ: header with no reason is a lex error, not a silent no-op."""
+    source = "NOFUZZ:\naxdef\n  n : N\nwhere\n  n = n\nend\n"
+    with pytest.raises(LexerError) as exc_info:
+        Lexer(source).tokenize()
+    assert "reason" in str(exc_info.value)
+
+
+def test_whitespace_only_reason_raises_lexer_error():
+    """A reason of only whitespace is treated as no reason at all."""
+    source = "NOFUZZ:   \naxdef\n  n : N\nwhere\n  n = n\nend\n"
+    with pytest.raises(LexerError):
+        Lexer(source).tokenize()
+
+
+def test_reason_is_rest_of_header_line():
+    """The reason is captured verbatim to end of line -- no END, no body slurp."""
+    tokens = Lexer("NOFUZZ: fuzz reads ^ as relation iteration\ngiven A\n").tokenize()
+    nofuzz_tokens = [t for t in tokens if t.type.name == "NOFUZZ"]
+    assert len(nofuzz_tokens) == 1
+    assert nofuzz_tokens[0].value == "fuzz reads ^ as relation iteration"
+
+
+# ---------------------------------------------------------------------------
+# Parser: NOFUZZ stamps nofuzz_reason via the box paragraph's normal grammar
+# ---------------------------------------------------------------------------
+
+
+def test_nofuzz_axdef_matches_locked_spec_example():
+    """The exact example from the locked spec parses to a NOFUZZ-marked AxDef."""
+    source = (
+        "NOFUZZ: fuzz reads ^ as relational iteration, not exponentiation\n"
+        "axdef\n"
+        "  square : N -> N\n"
+        "where\n"
+        "  forall n : N | square(n) = n^2\n"
+        "end\n"
+    )
+    doc = _parse(source)
+    node = doc.items[0]
+    assert isinstance(node, AxDef)
+    assert node.nofuzz_reason == (
+        "fuzz reads ^ as relational iteration, not exponentiation"
+    )
+
+
+def test_nofuzz_schema():
+    source = "NOFUZZ: reason\nschema Foo\n  n : N\nwhere\n  n = n^2\nend\n"
+    doc = _parse(source)
+    node = doc.items[0]
+    assert isinstance(node, Schema)
+    assert node.name == "Foo"
+    assert node.nofuzz_reason == "reason"
+
+
+def test_nofuzz_gendef_parses_but_is_marked():
+    """gendef NOFUZZ parses fine at the AST level; codegen rejects it later."""
+    source = (
+        "NOFUZZ: reason\ngendef [X]\n  f : X -> X\nwhere\n"
+        "  forall x : X | f(x) = x\nend\n"
+    )
+    doc = _parse(source)
+    node = doc.items[0]
+    assert isinstance(node, GenDef)
+    assert node.nofuzz_reason == "reason"
+
+
+def test_nofuzz_given_type():
+    doc = _parse("NOFUZZ: reason\ngiven A, B\n")
+    node = doc.items[0]
+    assert isinstance(node, GivenType)
+    assert node.names == ["A", "B"]
+    assert node.nofuzz_reason == "reason"
+
+
+def test_nofuzz_free_type():
+    doc = _parse("NOFUZZ: reason\nStatus ::= active | inactive\n")
+    node = doc.items[0]
+    assert isinstance(node, FreeType)
+    assert node.name == "Status"
+    assert node.nofuzz_reason == "reason"
+
+
+def test_nofuzz_abbreviation():
+    doc = _parse("NOFUZZ: reason\nSq == n^2\n")
+    node = doc.items[0]
+    assert isinstance(node, Abbreviation)
+    assert node.name == "Sq"
+    assert node.nofuzz_reason == "reason"
+
+
+def test_reason_with_colon_preserved():
+    """A reason containing its own colon is captured in full (rest of line)."""
+    doc = _parse("NOFUZZ: see RM 3.4: fuzz misreads ^\ngiven A\n")
+    node = doc.items[0]
+    assert isinstance(node, GivenType)
+    assert node.nofuzz_reason == "see RM 3.4: fuzz misreads ^"
+
+
+def test_nofuzz_not_followed_by_box_paragraph_raises_parser_error():
+    """NOFUZZ before prose (not a box paragraph) is a ParserError, not silent."""
+    source = "NOFUZZ: reason\nTEXT: hello\n"
+    with pytest.raises(ParserError) as exc_info:
+        _lex_and_parse(source)
+    assert "axdef, schema, gendef, given type, free type, or abbreviation" in str(
+        exc_info.value
+    )
+    assert "Paragraph" in str(exc_info.value)
+
+
+def test_nofuzz_at_end_of_input_raises_parser_error():
+    """NOFUZZ with nothing following it at all is a ParserError."""
+    source = "NOFUZZ: reason\n"
+    with pytest.raises(ParserError) as exc_info:
+        _lex_and_parse(source)
+    assert "axdef, schema, gendef, given type, free type, or abbreviation" in str(
+        exc_info.value
+    )
+
+
+# ---------------------------------------------------------------------------
+# Codegen: each box kind emits its correct twin
+# ---------------------------------------------------------------------------
+
+
+def test_axdef_emits_axdefnofuzz_twin_with_reason_and_body():
+    """axdef NOFUZZ emits axdefnofuzz{reason}, never axdef, same body."""
+    source = (
+        "NOFUZZ: fuzz reads ^ as relational iteration, not exponentiation\n"
+        "axdef\n"
+        "  square : N -> N\n"
+        "where\n"
+        "  forall n : N | square(n) = n^2\n"
+        "end\n"
+    )
+    latex = _parse_and_generate(source)
+    assert (
+        r"\begin{axdefnofuzz}{fuzz reads \textasciicircum{} as relational "
+        r"iteration, not exponentiation}" in latex
+    )
+    assert r"\end{axdefnofuzz}" in latex
+    assert r"\begin{axdef}" not in latex
+    assert r"\end{axdef}" not in latex
+    assert r"square : \nat \fun \nat" in latex
+    assert r"\forall n : \nat @ square(n) = n \bsup 2 \esup" in latex
+
+
+def test_given_type_emits_zednofuzz_twin():
+    latex = _parse_and_generate("NOFUZZ: reason\ngiven A, B\n")
+    assert r"\begin{zednofuzz}{reason}[A, B]\end{zednofuzz}" in latex
+    assert r"\begin{zed}" not in latex
+
+
+def test_free_type_emits_zednofuzz_twin():
+    latex = _parse_and_generate("NOFUZZ: reason\nStatus ::= active | inactive\n")
+    assert (
+        r"\begin{zednofuzz}{reason}Status ::= active | inactive\end{zednofuzz}" in latex
+    )
+    assert r"\begin{zed}" not in latex
+
+
+def test_abbreviation_emits_zednofuzz_twin():
+    latex = _parse_and_generate("NOFUZZ: reason\nSq == n^2\n")
+    assert r"\begin{zednofuzz}{reason}" in latex
+    assert r"Sq == n \bsup 2 \esup" in latex
+    assert r"\end{zednofuzz}" in latex
+    assert r"\begin{zed}" not in latex
+
+
+def test_schema_emits_two_arg_schemanofuzz_twin():
+    """schema NOFUZZ emits schemanofuzz{name}{reason} -- TWO args, name first."""
+    source = "NOFUZZ: schema reason\nschema Foo\n  n : N\nwhere\n  n = n^2\nend\n"
+    latex = _parse_and_generate(source)
+    assert r"\begin{schemanofuzz}{Foo}{schema reason}" in latex
+    assert r"\end{schemanofuzz}" in latex
+    assert r"\begin{schema}" not in latex
+    assert r"n = n \bsup 2 \esup" in latex
+
+
+def test_gendef_nofuzz_raises_not_implemented_error():
+    """No gendefnofuzz environment exists yet -- codegen rejects, doesn't emit it."""
+    source = (
+        "NOFUZZ: reason\ngendef [X]\n  f : X -> X\nwhere\n"
+        "  forall x : X | f(x) = x\nend\n"
+    )
+    doc = _parse(source)
+    with pytest.raises(NoFuzzGenDefNotImplementedError) as exc_info:
+        LaTeXGenerator(use_fuzz=True).generate_document(doc)
+    assert "gendefnofuzz not yet implemented" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Codegen: reason escaping (CRITICAL -- ^ and _ are common in real reasons)
+# ---------------------------------------------------------------------------
+
+
+def test_reason_escapes_caret():
+    latex = _parse_and_generate("NOFUZZ: fuzz reads ^ as iteration\ngiven A\n")
+    assert r"\textasciicircum{}" in latex
+    assert "reads ^ as" not in latex
+
+
+def test_reason_escapes_underscore():
+    latex = _parse_and_generate("NOFUZZ: fuzz misreads relation_iteration\ngiven A\n")
+    assert r"relation\_iteration" in latex
+    assert "relation_iteration" not in latex
+
+
+def test_reason_escapes_caret_and_underscore_together():
+    """The exact combination the locked spec calls out as CRITICAL."""
+    latex = _parse_and_generate(
+        "NOFUZZ: fuzz reads n^2 as iter_2 not exponentiation\ngiven A\n"
+    )
+    assert r"n\textasciicircum{}2" in latex
+    assert r"iter\_2" in latex
+
+
+# ---------------------------------------------------------------------------
+# Codegen: zed consolidation-break
+# ---------------------------------------------------------------------------
+
+
+def test_nofuzz_zed_item_breaks_consolidation():
+    """A NOFUZZ-marked item never joins a consolidated zed run.
+
+    A checked run before it and a checked run after it still consolidate
+    normally; the NOFUZZ item renders alone in its own zednofuzz box.
+    """
+    source = "given A\ngiven B\nNOFUZZ: mid reason\ngiven C\ngiven D\ngiven E\n"
+    latex = _parse_and_generate(source)
+    # Checked run before: A and B consolidated into one zed with \also.
+    assert r"\begin{zed}" in latex
+    assert "[A]" in latex
+    assert "[B]" in latex
+    assert r"\also" in latex
+    # NOFUZZ item alone in its own box.
+    assert r"\begin{zednofuzz}{mid reason}[C]\end{zednofuzz}" in latex
+    # Checked run after: D and E consolidated into their own zed with \also.
+    zed_envs = latex.count(r"\begin{zed}")
+    assert zed_envs == 2  # [A, B] run and [D, E] run, each its own box
+    assert "[D]" in latex
+    assert "[E]" in latex
+
+
+def test_nofuzz_lint_items_staged_per_box_kind():
+    """Each nofuzz_reason box stages a probe_snippet wrapped in its own kind."""
+    source = (
+        "NOFUZZ: axdef reason\naxdef\n  n : N\nwhere\n  n = n^2\nend\n"
+        "\n"
+        "NOFUZZ: given reason\ngiven A\n"
+    )
+    doc = _parse(source)
+    generator = LaTeXGenerator(use_fuzz=True)
+    generator.generate_document(doc)
+    assert len(generator.nofuzz_lint_items) == 2
+    axdef_item, given_item = generator.nofuzz_lint_items
+    assert axdef_item.reason == "axdef reason"
+    assert axdef_item.probe_snippet.startswith(r"\begin{axdef}")
+    assert axdef_item.probe_snippet.endswith(r"\end{axdef}")
+    assert given_item.reason == "given reason"
+    assert given_item.probe_snippet == r"\begin{zed}[A]\end{zed}"
+
+
+# ---------------------------------------------------------------------------
+# CLI lint: reject-if-clean (unit level, real fuzz)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _fuzz_available(), reason="fuzz binary not installed")
+def test_lint_rejects_clean_typechecking_content():
+    """fuzz accepting a NOFUZZ probe cleanly means the waiver is a lie -- reject."""
+    item = NoFuzzLintItem(
+        line=3, reason="reason", probe_snippet=r"\begin{zed}[A, B]\end{zed}"
+    )
+    assert lint_nofuzz_block(item) is False
+
+
+@pytest.mark.skipif(not _fuzz_available(), reason="fuzz binary not installed")
+def test_lint_accepts_genuinely_unparseable_content():
+    """fuzz genuinely rejecting the probe (the ^ misparse) justifies the waiver."""
+    item = NoFuzzLintItem(
+        line=3,
+        reason="reason",
+        probe_snippet=(
+            r"\begin{axdef}"
+            "\n"
+            r"square : \nat \fun \nat"
+            "\n"
+            r"\where"
+            "\n"
+            r"\forall n : \nat @ square(n) = n \bsup 2 \esup"
+            "\n"
+            r"\end{axdef}"
+        ),
+    )
+    assert lint_nofuzz_block(item) is True
+
+
+def test_lint_skips_when_fuzz_absent():
+    """No fuzz binary on PATH -> lint is skipped (None), never a hard failure."""
+    item = NoFuzzLintItem(
+        line=3, reason="reason", probe_snippet=r"\begin{zed}[A, B]\end{zed}"
+    )
+    with patch("shutil.which", return_value=None):
+        assert lint_nofuzz_block(item) is None
+
+
+# ---------------------------------------------------------------------------
+# CLI end-to-end: build fails/succeeds based on the lint outcome
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _fuzz_available(), reason="fuzz binary not installed")
+def test_cli_build_fails_when_nofuzz_content_is_clean(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A NOFUZZ box wrapping trivially-clean content fails the build."""
+    input_file = tmp_path / "clean_nofuzz.txt"
+    input_file.write_text("NOFUZZ: should have been a plain given\ngiven A, B\n")
+    with patch.object(sys, "argv", ["txt2tex", str(input_file), "--tex-only"]):
+        result = main()
+    assert result == 1
+    captured = capsys.readouterr()
+    assert "type-checks cleanly under fuzz" in captured.err
+    assert "use a plain box instead" in captured.err
+
+
+@pytest.mark.skipif(not _fuzz_available(), reason="fuzz binary not installed")
+def test_cli_build_succeeds_when_nofuzz_content_genuinely_fails(
+    tmp_path: Path,
+) -> None:
+    """A NOFUZZ axdef wrapping genuinely-unparseable content passes the build."""
+    input_file = tmp_path / "genuine_nofuzz.txt"
+    input_file.write_text(
+        "NOFUZZ: fuzz reads ^ as relational iteration, not exponentiation\n"
+        "axdef\n"
+        "  square : N -> N\n"
+        "where\n"
+        "  forall n : N | square(n) = n^2\n"
+        "end\n"
+    )
+    with patch.object(sys, "argv", ["txt2tex", str(input_file), "--tex-only"]):
+        result = main()
+    assert result == 0
+    output_file = input_file.with_suffix(".tex")
+    latex = output_file.read_text()
+    assert r"\begin{axdefnofuzz}" in latex
+
+
+@pytest.mark.skipif(not _fuzz_available(), reason="fuzz binary not installed")
+def test_cli_document_with_axdef_and_nofuzz_axdef_still_typechecks(
+    tmp_path: Path,
+) -> None:
+    """fuzz skips axdefnofuzz structurally: a real axdef alongside NOFUZZ
+    still gets type-checked, and the whole build succeeds."""
+    input_file = tmp_path / "mixed.txt"
+    input_file.write_text(
+        "axdef\n"
+        "  population : N\n"
+        "where\n"
+        "  population > 0\n"
+        "end\n"
+        "\n"
+        "NOFUZZ: fuzz reads ^ as relational iteration, not exponentiation\n"
+        "axdef\n"
+        "  square : N -> N\n"
+        "where\n"
+        "  forall n : N | square(n) = n^2\n"
+        "end\n"
+    )
+    with patch.object(sys, "argv", ["txt2tex", str(input_file), "--tex-only"]):
+        result = main()
+    assert result == 0
+
+
+def test_cli_gendef_nofuzz_error_surfaces_cleanly(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """NoFuzzGenDefNotImplementedError is caught -- one clean error, no traceback."""
+    input_file = tmp_path / "gendef_nofuzz.txt"
+    input_file.write_text(
+        "NOFUZZ: reason\ngendef [X]\n  f : X -> X\nwhere\n"
+        "  forall x : X | f(x) = x\nend\n"
+    )
+    with patch.object(sys, "argv", ["txt2tex", str(input_file), "--tex-only"]):
+        result = main()
+    assert result == 1
+    captured = capsys.readouterr()
+    assert "Error:" in captured.err
+    assert "gendefnofuzz not yet implemented" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_cli_nofuzz_lint_skipped_when_fuzz_not_installed(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """No fuzz on PATH: the NOFUZZ lint degrades gracefully, build still succeeds."""
+    input_file = tmp_path / "clean_nofuzz.txt"
+    input_file.write_text("NOFUZZ: should have been a plain given\ngiven A, B\n")
+    with (
+        patch.object(sys, "argv", ["txt2tex", str(input_file), "--tex-only"]),
+        patch("shutil.which", return_value=None),
+    ):
+        result = main()
+    assert result == 0
+    captured = capsys.readouterr()
+    assert "Skipping NOFUZZ lint" in captured.err


### PR DESCRIPTION
## What

Adds `NOFUZZ:`, a one-line modifier that marks a single Z box as **rendered but deliberately not type-checked by fuzz** — for genuine Z that fuzz's grammar cannot parse. The canonical case is numeric exponentiation `n^2`: the Z toolkit has no exponent operator, so fuzz reads `^` as *relational iteration* and rejects `n = n^2` with `n : N` even though it's the intended mathematics.

```text
NOFUZZ: fuzz reads ^ as relational iteration, not exponentiation
axdef
  square : N -> N
where
  forall n : N | square(n) = n^2
end
```

## Design (approved by the student; notation-honesty vetted by jms)

- The marked box renders **byte-identical to the checked box of the same kind** — no banner, no special frame. The only mark is one mandatory, non-suppressible italic note directly beneath it: `† not type-checked — <reason>`.
- Emitted in a **fuzz-invisible twin environment** (`axdefnofuzz` / `zednofuzz` / `schemanofuzz`), whose name is outside the literal set fuzz's scanner recognizes, so fuzz skips the box structurally and the rest of the document still type-checks.
- **Reject-if-clean lint:** each NOFUZZ body is probed in the *matching checked* environment; if it type-checks cleanly the build fails, so a waiver can't hide a real error.
- Supported box kinds: `axdef`, `schema`, `zed`-paragraphs (abbreviations, given sets, free types). `gendef` is deferred — marking one raises a clear not-yet-implemented error.

Rejected alternatives (see DESIGN.md ADR): a CI-level file-exclusion list (brittle, hides the waiver from the document) and a loud dashed-banner frame (ugly, stops reading as Z).

## Verification

- `make check` green — 5207 passed, 31 new NOFUZZ tests (lexer/parser/codegen/lint).
- End-to-end against real fuzz: a document mixing a checked `axdef` with NOFUZZ twins → `Type checking: passed` (fuzz skips the twins), PDF compiles, note renders. The reject-if-clean error and gendef rejection both verified from actual CLI runs.
- All doc snippets CLI-verified through to `pdftotext`.

## Follow-up (PR-2, not in this PR)

Sweep the failing `^` examples and mark/rewrite each; wire the CI fuzz gate so broken Z can't ship.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches lexer/parser/codegen, LaTeX preamble, and CLI fuzz probing; misconfiguration could let unchecked Z ship or break builds, but reject-if-clean lint and explicit unsupported cases limit abuse.
> 
> **Overview**
> Adds **`NOFUZZ: <reason>`**, a one-line prefix on a single Z box so it still renders like a normal formal paragraph but **fuzz skips type-checking** — aimed at genuine Z fuzz cannot parse (e.g. arithmetic `n^2` where `^` is relation iteration).
> 
> **Pipeline:** lexer requires a reason; parser stamps `nofuzz_reason` on the next `axdef` / `schema` / given / free type / abbreviation; codegen emits fuzz-invisible twins **`axdefnofuzz`**, **`schemanofuzz`**, **`zednofuzz`** from new **`zednofuzz.sty`** (same box shape as checked kinds) plus a mandatory **† not type-checked — reason** line. **`gendef`** is rejected until `gendefnofuzz` exists.
> 
> **Build-time guard:** after generation, the CLI probes each NOFUZZ body in the matching **checked** environment; if fuzz accepts it (or only complains about undeclared names), the build **fails** so waivers cannot hide fixable errors. Names declared only inside NOFUZZ boxes are excluded from fuzz-declaration tracking; NOFUZZ breaks `zed` consolidation and is disallowed with **`--zed`**, generics, stacked modifiers, and RA abbreviations.
> 
> Version **2.1.0**; docs ADR/user guide/changelog and **`tests/test_nofuzz_block.py`** added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4572aafc72ae43500a921dec7e642a577aa9ad8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->