### PR TITLE
feat(code): add CODE: verbatim block that consumes its END fence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-07-05
+
+### Added
+
+- **`CODE:` — general verbatim code block.** For embedding source code (SQL,
+  and the like) in a document. The body is captured verbatim until a line that
+  is exactly `END`, and — unlike `B:` — that terminating `END` is **consumed,
+  not rendered**:
+
+  ```text
+  CODE:
+  CREATE FUNCTION f() RETURNS trigger AS $$
+  BEGIN
+      IF NEW.x IS NULL THEN
+          RAISE EXCEPTION 'no';
+      END IF;
+      RETURN NEW;
+  END;
+  $$ LANGUAGE plpgsql;
+  END
+  ```
+
+  Lines that merely start with `END` — `END;`, `END IF;`, `END LOOP;` — are
+  code and are preserved; only a bare `END` line terminates the block. Renders
+  as `\begin{verbatim}…\end{verbatim}`, identical formatting to `B:`. A missing
+  terminator is a lexer error, and a literal `\end{verbatim}` in the body is
+  rejected (same safety posture as `B:`).
+
+  `B:` remains the B-Method machine block, which renders its terminating `END`
+  on purpose (it is B-Method's own keyword); `CODE:` is the right choice for
+  general code that should not show a trailing `END`.
+
 ## [2.1.0] - 2026-07-05
 
 ### Added

--- a/docs/guides/USER_GUIDE.md
+++ b/docs/guides/USER_GUIDE.md
@@ -397,6 +397,11 @@ END
 - A `B:` block opened without a matching `END` is a lexer error; the error
   message cites the source line of the `B:` opener.
 
+`B:` is for B-Method machines specifically, because it keeps the `END` that
+closes the machine. Writing SQL, Python, or any other code? Use
+[`CODE:`](#code---verbatim-code-block) instead — same verbatim rendering,
+but the fence's `END` is consumed rather than printed.
+
 **Why not use `LATEX:` for B machines?**
 
 `B:` wraps its body in `\begin{verbatim}…\end{verbatim}`, which gives you
@@ -425,6 +430,93 @@ END
 
 TEXT: The invariant ensures trains is a sequence of directed edges.
 ```
+
+### CODE: - Verbatim Code Block
+
+Use `CODE:` to embed a chunk of source code — SQL, Python, shell, whatever —
+verbatim, with fixed-width font and no escaping. It's the general-purpose
+sibling of `B:`: same rendering, but the fence itself doesn't leak into the
+output.
+
+**Syntax:**
+
+```text
+CODE:
+CREATE FUNCTION f() RETURNS trigger AS $$
+BEGIN
+    IF NEW.x IS NULL THEN
+        RAISE EXCEPTION 'no';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+END
+```
+
+renders as:
+
+```latex
+\begin{verbatim}
+CREATE FUNCTION f() RETURNS trigger AS $$
+BEGIN
+    IF NEW.x IS NULL THEN
+        RAISE EXCEPTION 'no';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+\end{verbatim}
+```
+
+Verified with `txt2tex --tex-only` on a file containing `TEXT:` before and
+after the block; the emitted LaTeX is pasted above unedited.
+
+**Rules:**
+
+- The `CODE:` line opens the block. Any text on the same line after `:` is
+  ignored.
+- Every line after `CODE:` is captured verbatim until a line that is
+  exactly `END` at column 0 (no leading whitespace, no trailing content
+  beyond a newline).
+- **The fence's `END` is consumed, not printed.** This is the one
+  difference from `B:`: `B:` keeps its terminating `END` because in
+  B-Method, `END` is the machine's own closing keyword. `CODE:` treats
+  `END` purely as a fence marker for the block — it isn't part of your
+  code, so it doesn't appear in the output.
+- Lines that merely *start with* `END` — `END;`, `END IF;`, `END LOOP;`,
+  and so on — are ordinary code, not the terminator. Only a line that is
+  exactly `END` and nothing else closes the block. That's why the
+  PL/pgSQL example above keeps its `END IF;` and `END;` lines but drops
+  the trailing bare `END` that closes the `CODE:` fence.
+- A `CODE:` block opened without a matching `END` is a lexer error citing
+  the source line of the `CODE:` opener:
+
+  ```text
+  Error: CODE: block opened at line 1 has no closing END
+  ```
+
+- A literal `\end{verbatim}` inside the body is rejected — it would close
+  the rendered `verbatim` environment early and let arbitrary LaTeX
+  through:
+
+  ```text
+  Error: CODE: block at line 1 contains a literal '\end{verbatim}' which
+  would prematurely terminate the rendered verbatim environment
+  ```
+
+  There's no in-band escape for this inside a LaTeX `verbatim`
+  environment, so rejection is the only safe option. If your code
+  genuinely needs that string, it can't go through `CODE:`.
+
+**`CODE:` vs. `B:`:**
+
+| | `B:` | `CODE:` |
+|---|---|---|
+| Use for | B-Method machines | General source code (SQL, Python, shell, …) |
+| Fence keyword | `END` | `END` |
+| Terminating `END` in output | Kept (it's the machine's own keyword) | Dropped (it's just a fence marker) |
+| `END;`, `END IF;`, etc. inside the body | Preserved as code | Preserved as code |
+| Rendering | `\begin{verbatim}...\end{verbatim}` | `\begin{verbatim}...\end{verbatim}` (identical) |
 
 ### LATEX: - Raw LaTeX Passthrough
 

--- a/src/txt2tex/__version__.py
+++ b/src/txt2tex/__version__.py
@@ -1,3 +1,3 @@
 """Defines the version of the txt2tex package."""
 
-__version__ = "2.1.0"
+__version__ = "2.2.0"

--- a/src/txt2tex/ast_nodes.py
+++ b/src/txt2tex/ast_nodes.py
@@ -1380,13 +1380,17 @@ class LatexBlock(ASTNode):
 
 @dataclass(frozen=True)
 class BMachine(ASTNode):
-    """B-machine verbatim block (B: ... END).
+    """Verbatim block backing both ``B:`` and ``CODE:``.
 
-    Body text is passed verbatim inside a LaTeX verbatim environment.
-    The body includes the terminating END line; indentation is preserved.
+    Body text is passed verbatim inside a LaTeX verbatim environment;
+    indentation is preserved. The two directives differ only in the
+    terminating ``END`` line: ``B:`` (a B-Method machine listing) keeps it
+    in the body — ``END`` is B-Method's own keyword — while ``CODE:`` (a
+    general code fence) consumes it. The lexer applies that choice, so by
+    the time the body reaches this node it is just raw verbatim text.
     """
 
-    body: str  # Raw multi-line body including the final END line
+    body: str  # Raw verbatim body (B: keeps the final END line; CODE: drops it)
 
 
 @dataclass(frozen=True)

--- a/src/txt2tex/codegen/text_blocks.py
+++ b/src/txt2tex/codegen/text_blocks.py
@@ -350,10 +350,12 @@ class _TextBlocksCodegen(CodegenDispatch):  # pyright: ignore[reportUnusedClass]
 
     @item_register.register(BMachine)
     def _generate_b_machine(self, node: BMachine) -> list[str]:
-        r"""Generate LaTeX for B-machine verbatim block.
+        r"""Generate LaTeX for a verbatim block (backs both B: and CODE:).
 
         Wraps the body in \begin{verbatim}…\end{verbatim}.
-        Body indentation and blank lines are preserved exactly.
+        Body indentation and blank lines are preserved exactly. Whether the
+        body carries a trailing END line was decided at lex time (B: keeps
+        it, CODE: drops it); this renderer treats the body as opaque text.
         """
         lines: list[str] = []
         lines.append(r"\begin{verbatim}")

--- a/src/txt2tex/lexer.py
+++ b/src/txt2tex/lexer.py
@@ -1344,53 +1344,25 @@ class Lexer:
 
         # Check for B: keyword — B-machine verbatim block.
         # Consume body lines verbatim until a line that is exactly "END" at
-        # column 0 (no leading whitespace, optional trailing newline).
-        # The END line itself is included in the body.
+        # column 0 (no leading whitespace, optional trailing newline). The
+        # END line itself is included in the body: in B-Method, END is the
+        # machine's own keyword, not a delimiter txt2tex invented.
         if value == "B" and self._current_char() == ":":
             self._advance()  # consume ':'
-            # Skip optional trailing whitespace/rest of B: line up to newline
-            while not self._at_end() and self._current_char() != "\n":
-                self._advance()
-            # Consume the newline that ends the B: line, if present
-            if not self._at_end() and self._current_char() == "\n":
-                self._advance()
-            # Slurp body lines verbatim until column-0 END
-            body_lines: list[str] = []
-            found_end = False
-            while not self._at_end():
-                # Scan one line
-                line_start = self.pos
-                while not self._at_end() and self._current_char() != "\n":
-                    self._advance()
-                # Capture the line content (without its trailing newline)
-                raw_line = self.text[line_start : self.pos]
-                # Consume the newline, if present
-                if not self._at_end() and self._current_char() == "\n":
-                    self._advance()
-                body_lines.append(raw_line)
-                # Check if this line is the terminator: exactly "END"
-                if raw_line == "END":
-                    found_end = True
-                    break
-            if not found_end:
-                raise LexerError(
-                    f"B: block opened at line {start_line} has no closing END",
-                    start_line,
-                    start_column,
-                )
-            body = "\n".join(body_lines)
-            # Reject a literal \end{verbatim} in the body: it would close the
-            # generator's verbatim env early and let arbitrary LaTeX follow.
-            # No in-band escape exists inside LaTeX verbatim; rejection is the
-            # only safe posture (djb 2026-05-22 review).
-            if "\\end{verbatim}" in body:
-                raise LexerError(
-                    f"B: block at line {start_line} contains a literal "
-                    f"'\\end{{verbatim}}' which would prematurely terminate "
-                    f"the rendered verbatim environment",
-                    start_line,
-                    start_column,
-                )
+            body = self._scan_verbatim_block(
+                "B", start_line, start_column, keep_terminator=True
+            )
+            return Token(TokenType.B_BLOCK, body, start_line, start_column)
+
+        # Check for CODE: keyword — general verbatim code fence (SQL,
+        # PL/pgSQL, etc). Shares B:'s lexing, AST node (BMachine), and
+        # rendering; the terminating END is a pure delimiter here, so it is
+        # consumed rather than rendered (unlike B:'s own END keyword).
+        if value == "CODE" and self._current_char() == ":":
+            self._advance()  # consume ':'
+            body = self._scan_verbatim_block(
+                "CODE", start_line, start_column, keep_terminator=False
+            )
             return Token(TokenType.B_BLOCK, body, start_line, start_column)
 
         # Check for NOFUZZ: keyword — a one-line modifier marking the
@@ -1630,6 +1602,71 @@ class Lexer:
 
         # Regular identifier (includes seq, seq1)
         return Token(TokenType.IDENTIFIER, value, start_line, start_column)
+
+    def _scan_verbatim_block(
+        self,
+        keyword: str,
+        start_line: int,
+        start_column: int,
+        *,
+        keep_terminator: bool,
+    ) -> str:
+        """Slurp lines verbatim until a column-0 ``END`` line; return the body.
+
+        Shared by ``B:`` (B-machine) and ``CODE:`` (general code fence) —
+        the two differ only in whether the caller wants the literal
+        terminator line folded into the body. Assumes the opening
+        ``<keyword>:`` has already been consumed up to and including the
+        colon; this method consumes the rest of that line, then the body.
+
+        A line counts as the terminator only when it is exactly ``END``
+        (no leading/trailing text) — ``END;``, ``END IF;`` and similar are
+        ordinary body lines.
+        """
+        # Skip optional trailing whitespace/rest of the header line.
+        while not self._at_end() and self._current_char() != "\n":
+            self._advance()
+        # Consume the newline that ends the header line, if present.
+        if not self._at_end() and self._current_char() == "\n":
+            self._advance()
+
+        body_lines: list[str] = []
+        found_end = False
+        while not self._at_end():
+            line_start = self.pos
+            while not self._at_end() and self._current_char() != "\n":
+                self._advance()
+            raw_line = self.text[line_start : self.pos]
+            if not self._at_end() and self._current_char() == "\n":
+                self._advance()
+            if raw_line == "END":
+                found_end = True
+                if keep_terminator:
+                    body_lines.append(raw_line)
+                break
+            body_lines.append(raw_line)
+
+        if not found_end:
+            raise LexerError(
+                f"{keyword}: block opened at line {start_line} has no closing END",
+                start_line,
+                start_column,
+            )
+
+        body = "\n".join(body_lines)
+        # Reject a literal \end{verbatim} in the body: it would close the
+        # generator's verbatim env early and let arbitrary LaTeX follow.
+        # No in-band escape exists inside LaTeX verbatim; rejection is the
+        # only safe posture (djb 2026-05-22 review).
+        if "\\end{verbatim}" in body:
+            raise LexerError(
+                f"{keyword}: block at line {start_line} contains a literal "
+                f"'\\end{{verbatim}}' which would prematurely terminate "
+                f"the rendered verbatim environment",
+                start_line,
+                start_column,
+            )
+        return body
 
     def _scan_number(self, start_line: int, start_column: int) -> Token:
         """Scan number."""

--- a/src/txt2tex/parser_pkg/text_blocks.py
+++ b/src/txt2tex/parser_pkg/text_blocks.py
@@ -241,10 +241,12 @@ class _TextBlocksParser(ParserBase):  # pyright: ignore[reportUnusedClass]
         )
 
     def _parse_b_block(self) -> BMachine:
-        """Parse B-machine verbatim block from B_BLOCK token.
+        """Parse a verbatim block (B: or CODE:) from a B_BLOCK token.
 
-        The token value is the raw multi-line body (including the final END
-        line) already captured by the lexer.  No Z-parser involvement.
+        The token value is the raw multi-line body already captured by the
+        lexer.  Whether the terminating END line is part of that body is
+        decided at lex time — B: keeps it, CODE: drops it — so the parser
+        just wraps whatever it received.  No Z-parser involvement.
         """
         b_token = self._advance()  # Consume B_BLOCK token
         if b_token.type != TokenType.B_BLOCK:

--- a/src/txt2tex/tokens.py
+++ b/src/txt2tex/tokens.py
@@ -144,7 +144,7 @@ class TokenType(Enum):
     LINEBREAK = auto()  # LINEBREAK: (insert \medskip vertical space)
     CONTENTS = auto()  # CONTENTS: (table of contents)
     PARTS = auto()  # PARTS: (parts formatting style)
-    B_BLOCK = auto()  # B: (B-machine verbatim block, terminated by column-0 END)
+    B_BLOCK = auto()  # B:/CODE: verbatim block, col-0 END terminator
     RAW_LATEX_BLOCK = auto()  # LATEX:\n...END (multi-line raw LaTeX, col-0 END)
     NOFUZZ = auto()  # NOFUZZ: reason (one-line modifier on next box paragraph)
     BIBLIOGRAPHY = auto()  # BIBLIOGRAPHY: (bibliography file)

--- a/tests/test_code_block.py
+++ b/tests/test_code_block.py
@@ -1,0 +1,117 @@
+"""Tests for CODE: block (general verbatim code fence).
+
+CODE: shares its lexing, AST node (BMachine), and rendering with B:, the
+B-machine verbatim block. The one behavioral difference: B:'s terminating
+END is B-Method's own keyword and is rendered; CODE:'s terminating END is
+a pure delimiter and is consumed, never rendered. See lexer.py's shared
+`_scan_verbatim_block` helper.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from txt2tex.ast_nodes import BMachine, Document
+from txt2tex.latex_gen import LaTeXGenerator
+from txt2tex.lexer import Lexer, LexerError
+from txt2tex.parser import Parser
+
+
+def _parse_and_generate(source: str) -> str:
+    """Return the LaTeX output for source."""
+    tokens = Lexer(source).tokenize()
+    ast = Parser(tokens).parse()
+    return LaTeXGenerator().generate_document(ast)
+
+
+# ---------------------------------------------------------------------------
+# Terminating END is consumed, not rendered
+# ---------------------------------------------------------------------------
+
+
+def test_code_block_end_terminator_consumed() -> None:
+    """The bare CODE: terminator is dropped from the rendered verbatim body."""
+    source = "CODE:\nSELECT 1;\nEND;\nEND\n"
+    latex = _parse_and_generate(source)
+    begin_pos = latex.index(r"\begin{verbatim}")
+    end_pos = latex.index(r"\end{verbatim}")
+    body_lines = (
+        latex[begin_pos + len(r"\begin{verbatim}") : end_pos].strip("\n").splitlines()
+    )
+    assert body_lines == ["SELECT 1;", "END;"]
+
+
+def test_code_block_full_rendered_latex() -> None:
+    """Exact rendered LaTeX for a minimal SQL CODE: block."""
+    source = "CODE:\nSELECT 1;\nEND;\nEND\n"
+    latex = _parse_and_generate(source)
+    begin_pos = latex.index(r"\begin{verbatim}")
+    end_pos = latex.index(r"\end{verbatim}") + len(r"\end{verbatim}")
+    rendered = latex[begin_pos:end_pos]
+    assert rendered == "\\begin{verbatim}\nSELECT 1;\nEND;\n\\end{verbatim}"
+
+
+def test_code_block_ast_body_excludes_terminator() -> None:
+    """The BMachine AST body for a CODE: block excludes the bare END line."""
+    source = "CODE:\nSELECT 1;\nEND;\nEND\n"
+    tokens = Lexer(source).tokenize()
+    ast = Parser(tokens).parse()
+    assert isinstance(ast, Document)
+    node = ast.items[0]
+    assert isinstance(node, BMachine)
+    assert node.body == "SELECT 1;\nEND;"
+
+
+# ---------------------------------------------------------------------------
+# Lines merely starting with END are code, not terminators
+# ---------------------------------------------------------------------------
+
+
+def test_end_if_and_end_loop_preserved_inside_code_block() -> None:
+    """END IF; and END LOOP; are PL/pgSQL code, not CODE: terminators."""
+    source = "CODE:\nBEGIN\n  IF x > 0 THEN\n    NULL;\n  END IF;\nEND LOOP;\nEND\n"
+    latex = _parse_and_generate(source)
+    assert "END IF;" in latex
+    assert "END LOOP;" in latex
+    # Only one closing \end{verbatim} — the bare terminator was consumed,
+    # not left behind as trailing body text.
+    assert latex.count(r"\end{verbatim}") == 1
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+
+def test_code_block_missing_end_raises_lexer_error_naming_code() -> None:
+    """A CODE: block without a closing END raises LexerError naming CODE:."""
+    source = "CODE:\nSELECT 1;\n"
+    with pytest.raises(LexerError) as exc_info:
+        Lexer(source).tokenize()
+    assert "CODE:" in str(exc_info.value)
+    assert "1" in str(exc_info.value)
+    assert "END" in str(exc_info.value)
+
+
+def test_code_block_with_literal_end_verbatim_is_rejected() -> None:
+    """A CODE: body containing \\end{verbatim} would escape the verbatim env."""
+    source = "CODE:\nSELECT 1;\n\\end{verbatim}\n\\write18{anything}\nEND\n"
+    with pytest.raises(LexerError) as exc_info:
+        Lexer(source).tokenize()
+    assert "\\end{verbatim}" in str(exc_info.value)
+    assert "CODE:" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Regression guard: B: is unaffected by the shared-helper refactor
+# ---------------------------------------------------------------------------
+
+
+def test_b_block_end_terminator_still_rendered() -> None:
+    """B: keeps rendering its terminating END — CODE:'s behavior must not leak."""
+    source = "B:\nMACHINE Foo\nEND\n"
+    latex = _parse_and_generate(source)
+    begin_pos = latex.index(r"\begin{verbatim}")
+    end_pos = latex.index(r"\end{verbatim}")
+    body_region = latex[begin_pos + len(r"\begin{verbatim}") : end_pos].strip()
+    assert body_region.endswith("END")


### PR DESCRIPTION
## What

Adds **`CODE:`** — a general verbatim code block for embedding source code (SQL, PL/pgSQL, …). Body captured verbatim until a line that is exactly `END`; that terminating `END` is **consumed, not rendered**.

```text
CODE:
CREATE FUNCTION f() RETURNS trigger AS $$
BEGIN
    IF NEW.x IS NULL THEN
        RAISE EXCEPTION 'no';
    END IF;
    RETURN NEW;
END;
$$ LANGUAGE plpgsql;
END
```
→ the `\begin{verbatim}` block contains everything through `$$ LANGUAGE plpgsql;`; the bare fence `END` does not appear. `END;` / `END IF;` / `END LOOP;` are preserved as code — only a bare `END` line terminates.

## Why

`B:` is the B-Machine verbatim block: it renders its terminating `END` **on purpose** (in B-Method, `END` is the machine's own keyword). Students embedding SQL used `B:` off-label and got a stray `END` printed at the bottom of every block. `CODE:` is the right tool — same verbatim formatting, fence consumed.

## Design

`CODE:` reuses `B:`'s entire pipeline — same `B_BLOCK` token → `BMachine` node → `\begin{verbatim}` codegen. The only difference is lexer-side: a shared `Lexer._scan_verbatim_block(keyword, ..., *, keep_terminator)` helper, called with `keep_terminator=True` for `B:` and `False` for `CODE:`. No new token, AST node, or codegen path.

## Verification

- `B:` is byte-identical — explicit regression test plus the existing `tests/test_b_block.py` (12 tests) pass unchanged.
- 7 new `CODE:` tests: terminator consumption, exact emitted LaTeX, `END;`/`END IF;`/`END LOOP;` preserved, missing-`END` error (names `CODE:`), literal `\end{verbatim}` rejection.
- CLI-verified end-to-end on a realistic PL/pgSQL trigger. `make check` green — 5223 passed.
- Docs: new USER_GUIDE `CODE:` section + a `B:`→`CODE:` pointer, every snippet CLI-verified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive lexer feature with shared helper and regression tests; B: behavior is explicitly preserved.
> 
> **Overview**
> **Release 2.2.0** adds **`CODE:`**, a general-purpose verbatim code fence (SQL, PL/pgSQL, etc.) that reuses the same path as **`B:`** (`B_BLOCK` → `BMachine` → `\begin{verbatim}`) without new AST or codegen.
> 
> The behavioral split is lexer-only: shared **`Lexer._scan_verbatim_block(..., keep_terminator=...)`** — **`B:`** keeps a column-0 **`END`** in the body (B-Method keyword); **`CODE:`** drops that fence line so it does not print. Lines like **`END;`** / **`END IF;`** stay body text; only a bare **`END`** closes the block. Missing **`END`** and literal **`\end{verbatim}`** in the body still error (keyword named in the message for **`CODE:`**).
> 
> Docs (**CHANGELOG**, **USER_GUIDE** **`CODE:`** section and **`B:`** pointer) and seven tests cover terminator consumption, preserved **`END;`** forms, errors, and a **`B:`** regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f4d981d597f0d5a79500cd74cd8708759588a46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->